### PR TITLE
fix: bug page refresh when change window

### DIFF
--- a/apps/catalog-admin/hooks/code-lists.ts
+++ b/apps/catalog-admin/hooks/code-lists.ts
@@ -17,6 +17,7 @@ export const useGetAllCodeLists = ({ catalogId }) => {
       });
       return response.json();
     },
+    refetchOnWindowFocus: false,
   });
 };
 

--- a/apps/catalog-admin/hooks/user-list.ts
+++ b/apps/catalog-admin/hooks/user-list.ts
@@ -17,6 +17,7 @@ export const useGetUsers = (catalogId: string) => {
       });
       return response.json();
     },
+    refetchOnWindowFocus: false,
   });
 };
 


### PR DESCRIPTION
Tror dette fikser feilen Kjersti beskrev:

> Det ser ut som det skjer noe rart med kodelistesiden når jeg har den oppe over tid (ikke mer enn 5-10 min), kan ha sammenheng med at jeg er inne i andre faner eller vinduer. Listen over kodelister blir tom, så kommer den plutselig tilbake når vinduet/fanen har vært aktiv noen sekunder. 