### PR TITLE
feat: create and replace status tags

### DIFF
--- a/apps/concept-catalog/app/[catalogId]/[conceptId]/concept-page-client.tsx
+++ b/apps/concept-catalog/app/[catalogId]/[conceptId]/concept-page-client.tsx
@@ -13,6 +13,7 @@ import {
   Button,
   Pagination,
   DetailsPageLayout,
+  Tag,
 } from '@catalog-frontend/ui';
 import {
   localization,
@@ -21,12 +22,11 @@ import {
   validOrganizationNumber,
   validUUID,
   ensureStringArray,
-  getTagColorVariant,
 } from '@catalog-frontend/utils';
 import { Concept, Comment, Update, CodeList, InternalField, AssignedUser } from '@catalog-frontend/types';
 import { ChatIcon, EnvelopeClosedIcon, PhoneIcon } from '@navikt/aksel-icons';
 import cn from 'classnames';
-import { Accordion, Switch, Tabs, Tag, Textarea } from '@digdir/design-system-react';
+import { Accordion, Switch, Tabs, Textarea } from '@digdir/design-system-react';
 import _ from 'lodash';
 import classes from './concept-page.module.css';
 import { useCreateComment, useDeleteComment, useGetComments, useUpdateComment } from '../../../hooks/comments';
@@ -343,7 +343,10 @@ export const ConceptPageClient = ({
                 </div>
                 {status && (
                   <div className={cn(classes.status)}>
-                    <Tag color={getTagColorVariant(getStatusFromURL(revision))}>{status}</Tag>
+                    <Tag.ConceptStatus
+                      statusKey={getStatusFromURL(revision)}
+                      statusLabel={status}
+                    />
                   </div>
                 )}
               </div>
@@ -741,7 +744,12 @@ export const ConceptPageClient = ({
         headingTitle={
           <div className={cn(classes.status)}>
             <h2>{getTitle(translate(concept?.anbefaltTerm?.navn, language))}</h2>
-            {status && <Tag color={getTagColorVariant(getStatusFromURL(concept))}>{status}</Tag>}
+            {status && (
+              <Tag.ConceptStatus
+                statusKey={getStatusFromURL(concept)}
+                statusLabel={status}
+              />
+            )}
           </div>
         }
         headingSubtitle={getDetailSubtitle()}

--- a/apps/concept-catalog/app/[catalogId]/change-requests/change-requests-page-client.tsx
+++ b/apps/concept-catalog/app/[catalogId]/change-requests/change-requests-page-client.tsx
@@ -1,6 +1,13 @@
 'use client';
 
-import { BreadcrumbType, Breadcrumbs, Button, PageBanner } from '@catalog-frontend/ui';
+import {
+  BreadcrumbType,
+  Breadcrumbs,
+  Button,
+  ChangeRequestStatusTagProps,
+  PageBanner,
+  Tag,
+} from '@catalog-frontend/ui';
 import {
   capitalizeFirstLetter,
   convertTimestampToDateAndTime,
@@ -9,7 +16,7 @@ import {
   validUUID,
 } from '@catalog-frontend/utils';
 import styles from './change-requests-page.module.css';
-import { Alert, Heading, Paragraph, Tag } from '@digdir/design-system-react';
+import { Alert, Heading, Paragraph } from '@digdir/design-system-react';
 import { useCatalogDesign } from '../../../context/catalog-design';
 import cn from 'classnames';
 import ChangeRequestFilter from '../../../components/change-request-filter';
@@ -131,19 +138,6 @@ export const ChangeRequestsPageClient = ({ catalogId, organization, data, FDK_RE
       .find(([key]) => key === status.toLowerCase())?.[1]
       .toString();
 
-  const getStatusColorVariant = (status: string) => {
-    switch (status.toLowerCase()) {
-      case 'open':
-        return 'warning';
-      case 'accepted':
-        return 'success';
-      case 'rejected':
-        return 'danger';
-      default:
-        return 'neutral';
-    }
-  };
-
   return (
     <>
       <Breadcrumbs
@@ -241,12 +235,10 @@ export const ChangeRequestsPageClient = ({ catalogId, organization, data, FDK_RE
                       </div>
                       {status && (
                         <div className={styles.status}>
-                          <Tag
-                            color={getStatusColorVariant(status)}
-                            size='small'
-                          >
-                            {getTranslatedStatus(status)}
-                          </Tag>
+                          <Tag.ChangeRequestStatus
+                            statusKey={status}
+                            statusLabel={getTranslatedStatus(status) as ChangeRequestStatusTagProps['statusLabel']}
+                          />
                         </div>
                       )}
                     </div>

--- a/apps/concept-catalog/components/concept-search-hits/index.tsx
+++ b/apps/concept-catalog/components/concept-search-hits/index.tsx
@@ -7,10 +7,9 @@ import {
   formatISO,
   validOrganizationNumber,
   validUUID,
-  getTagColorVariant,
 } from '@catalog-frontend/utils';
 import cn from 'classnames';
-import { ConceptSubject, SearchHit } from '@catalog-frontend/ui';
+import { ConceptStatusTagProps, ConceptSubject, SearchHit, Tag } from '@catalog-frontend/ui';
 import Link from 'next/link';
 import styles from './concept-search-hits.module.css';
 import { Chip } from '@digdir/design-system-react';
@@ -109,8 +108,12 @@ const ConceptSearchHits: React.FC<Props> = ({
               description={translate(concept?.definisjon?.tekst)}
               labels={<ConceptLabels searchHit={concept} />}
               content={<ConceptPublishingInfo searchHit={concept} />}
-              status={translate(findConceptStatus(concept.statusURI)?.label) as string}
-              statusColor={getTagColorVariant(findConceptStatus(concept.statusURI)?.code)}
+              statusTag={
+                <Tag.ConceptStatus
+                  statusKey={findConceptStatus(concept.statusURI)?.code as ConceptStatusTagProps['statusKey']}
+                  statusLabel={translate(findConceptStatus(concept.statusURI)?.label) as string}
+                />
+              }
               titleHref={
                 validOrganizationNumber(catalogId) && validUUID(concept.id) ? `/${catalogId}/${concept.id}` : '#'
               }

--- a/apps/service-catalog/app/catalogs/[catalogId]/public-services/[serviceId]/public-service-details-page-client.tsx
+++ b/apps/service-catalog/app/catalogs/[catalogId]/public-services/[serviceId]/public-service-details-page-client.tsx
@@ -1,7 +1,7 @@
 'use client';
 import { ReferenceDataCode, Service } from '@catalog-frontend/types';
-import { DetailsPageLayout, InfoCard } from '@catalog-frontend/ui';
-import { getTagColorVariant, getTranslateText, localization } from '@catalog-frontend/utils';
+import { Button, DetailsPageLayout, InfoCard, ServiceStatusTagProps, Tag } from '@catalog-frontend/ui';
+import { getTranslateText, localization } from '@catalog-frontend/utils';
 
 import _ from 'lodash';
 
@@ -11,8 +11,6 @@ import PublishSwitch from '../../../../../components/publish-switch';
 import BasicServiceFormInfoCardItems from '../../../../../components/basic-form-info-card-items';
 import { useState } from 'react';
 import styles from './public-service-details-page.module.css';
-import { Tag } from '@digdir/design-system-react';
-import { Button } from '@catalog-frontend/ui';
 
 interface PublicServiceDetailsPageProps {
   service: Service;
@@ -77,10 +75,11 @@ const PublicServiceDetailsPageClient = ({
       headingTitle={
         <div className={styles.status}>
           <h2>{getTranslateText(service?.title ?? '', language)}</h2>
-          {service.status !== 'Ingen status' && (
-            <Tag color={getTagColorVariant(findServiceStatus()?.code)}>
-              {getTranslateText(findServiceStatus()?.label) as string}
-            </Tag>
+          {service?.status && (
+            <Tag.ServiceStatus
+              statusKey={findServiceStatus()?.code as ServiceStatusTagProps['statusKey']}
+              statusLabel={getTranslateText(findServiceStatus()?.label) as string}
+            />
           )}
         </div>
       }

--- a/apps/service-catalog/app/catalogs/[catalogId]/public-services/public-service-page-client.tsx
+++ b/apps/service-catalog/app/catalogs/[catalogId]/public-services/public-service-page-client.tsx
@@ -5,7 +5,7 @@ import Link from 'next/link';
 import Filter from '../../../../components/filter';
 import { Service, ReferenceDataCode, FilterType } from '@catalog-frontend/types';
 import { getTranslateText, localization } from '@catalog-frontend/utils';
-import { SearchHit, SearchHitContainer, SearchHitsPageLayout } from '@catalog-frontend/ui';
+import { SearchHit, SearchHitContainer, SearchHitsPageLayout, ServiceStatusTagProps, Tag } from '@catalog-frontend/ui';
 import styles from './public-service-page.module.css';
 import { AddButton } from '../../../../components/buttons';
 import FilterChips from '../../../../components/filter-chips';
@@ -59,6 +59,8 @@ const PublicServicePageClient = ({ services, hasWritePermission, catalogId, stat
         break;
     }
   };
+
+  const findServiceStatus = (service: Service) => statuses.find((s) => s.uri === service?.status);
 
   return (
     <SearchHitsPageLayout
@@ -115,7 +117,14 @@ const PublicServicePageClient = ({ services, hasWritePermission, catalogId, stat
                   title={getTranslateText(service?.title)}
                   description={getTranslateText(service?.description)}
                   titleHref={`/catalogs/${catalogId}/public-services/${service?.id}`}
-                  status={getTranslateText(statuses.find((s) => s.uri === service?.status)?.label) as string}
+                  statusTag={
+                    service?.status && (
+                      <Tag.ServiceStatus
+                        statusKey={findServiceStatus(service)?.code as ServiceStatusTagProps['statusKey']}
+                        statusLabel={getTranslateText(findServiceStatus(service)?.label) as string}
+                      />
+                    )
+                  }
                   content={
                     service.published
                       ? localization.publicationState.publishedInFDK

--- a/apps/service-catalog/app/catalogs/[catalogId]/services/[serviceId]/service-details-page-client.tsx
+++ b/apps/service-catalog/app/catalogs/[catalogId]/services/[serviceId]/service-details-page-client.tsx
@@ -1,7 +1,7 @@
 'use client';
 import { ReferenceDataCode, Service } from '@catalog-frontend/types';
-import { DetailsPageLayout, InfoCard } from '@catalog-frontend/ui';
-import { getTagColorVariant, getTranslateText, localization } from '@catalog-frontend/utils';
+import { DetailsPageLayout, InfoCard, ServiceStatusTagProps, Tag } from '@catalog-frontend/ui';
+import { getTranslateText, localization } from '@catalog-frontend/utils';
 
 import _ from 'lodash';
 
@@ -11,7 +11,7 @@ import PublishSwitch from '../../../../../components/publish-switch';
 import BasicServiceFormInfoCardItems from '../../../../../components/basic-form-info-card-items';
 import { useState } from 'react';
 import styles from './service-details-page.module.css';
-import { Button, Tag } from '@digdir/design-system-react';
+import { Button } from '@digdir/design-system-react';
 
 interface ServiceDetailsPageProps {
   service: Service;
@@ -74,10 +74,11 @@ const ServiceDetailsPageClient = ({
       headingTitle={
         <div className={styles.status}>
           <h2>{getTranslateText(service?.title ?? '', language)}</h2>
-          {service.status !== 'Ingen status' && (
-            <Tag color={getTagColorVariant(findServiceStatus()?.code)}>
-              {getTranslateText(findServiceStatus()?.label) as string}
-            </Tag>
+          {service.status && (
+            <Tag.ServiceStatus
+              statusKey={findServiceStatus()?.code as ServiceStatusTagProps['statusKey']}
+              statusLabel={getTranslateText(findServiceStatus()?.label) as string}
+            />
           )}
         </div>
       }

--- a/apps/service-catalog/app/catalogs/[catalogId]/services/[serviceId]/service-details-page.module.css
+++ b/apps/service-catalog/app/catalogs/[catalogId]/services/[serviceId]/service-details-page.module.css
@@ -7,3 +7,9 @@
   gap: 1rem;
   margin: 0em 0 1em 0;
 }
+
+.status {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}

--- a/apps/service-catalog/app/catalogs/[catalogId]/services/service-page-client.tsx
+++ b/apps/service-catalog/app/catalogs/[catalogId]/services/service-page-client.tsx
@@ -5,7 +5,7 @@ import Link from 'next/link';
 import Filter from '../../../../components/filter';
 import { Service, ReferenceDataCode, FilterType } from '@catalog-frontend/types';
 import { getTranslateText, localization } from '@catalog-frontend/utils';
-import { SearchHit, SearchHitContainer, SearchHitsPageLayout } from '@catalog-frontend/ui';
+import { SearchHit, SearchHitContainer, SearchHitsPageLayout, ServiceStatusTagProps, Tag } from '@catalog-frontend/ui';
 import styles from './service-page.module.css';
 import { AddButton } from '../../../../components/buttons';
 import FilterChips from '../../../../components/filter-chips';
@@ -59,6 +59,8 @@ const ServicePageClient = ({ services, hasWritePermission, catalogId, statuses }
         break;
     }
   };
+
+  const findServiceStatus = (service: Service) => statuses.find((s) => s.uri === service?.status);
 
   return (
     <SearchHitsPageLayout
@@ -115,7 +117,14 @@ const ServicePageClient = ({ services, hasWritePermission, catalogId, statuses }
                   title={getTranslateText(service?.title)}
                   description={getTranslateText(service?.description)}
                   titleHref={`/catalogs/${catalogId}/services/${service?.id}`}
-                  status={getTranslateText(statuses.find((s) => s.uri === service?.status)?.label) as string}
+                  statusTag={
+                    service?.status && (
+                      <Tag.ServiceStatus
+                        statusKey={findServiceStatus(service)?.code as ServiceStatusTagProps['statusKey']}
+                        statusLabel={getTranslateText(findServiceStatus(service)?.label) as string}
+                      />
+                    )
+                  }
                   content={
                     service.published
                       ? localization.publicationState.publishedInFDK

--- a/libs/ui/src/index.ts
+++ b/libs/ui/src/index.ts
@@ -30,3 +30,4 @@ export * from './lib/details-page-layout';
 export * from './lib/form-field-card';
 export * from './lib/divider-line';
 export * from './lib/search-hits-page-layout';
+export * from './lib/tag';

--- a/libs/ui/src/lib/search-hit/index.tsx
+++ b/libs/ui/src/lib/search-hit/index.tsx
@@ -3,20 +3,18 @@ import styles from './search-hit.module.css';
 import Link from 'next/link';
 import { ReactNode } from 'react';
 import { Url } from 'next/dist/shared/lib/router/router';
-import { Tag } from '@digdir/design-system-react';
 
 interface Props {
   title: string[] | string;
   description?: string[] | string;
-  status?: string;
-  statusColor?: string;
   conceptSubject?: ReactNode;
   content?: ReactNode;
   titleHref?: Url;
   labels?: ReactNode;
+  statusTag?: ReactNode;
 }
 
-const SearchHit = ({ title, description, content, status, statusColor, titleHref, conceptSubject, labels }: Props) => {
+const SearchHit = ({ title, description, content, statusTag, titleHref, conceptSubject, labels }: Props) => {
   return (
     <div className={styles.container}>
       <div className={styles.rowSpaceBetween}>
@@ -24,11 +22,7 @@ const SearchHit = ({ title, description, content, status, statusColor, titleHref
           <Link href={titleHref ?? ''}>
             <h2 className={styles.title}>{translate(title) ? translate(title) : localization.concept.noName}</h2>
           </Link>
-          {status && (
-            <div className={styles.status}>
-              <Tag color={statusColor}>{status}</Tag>
-            </div>
-          )}
+          {statusTag && <div className={styles.status}>{statusTag}</div>}
         </div>
         {conceptSubject}
       </div>

--- a/libs/ui/src/lib/tag/change-request-status/ChangeRequestStatus.tsx
+++ b/libs/ui/src/lib/tag/change-request-status/ChangeRequestStatus.tsx
@@ -1,0 +1,37 @@
+import { Tag as DSTag, type TagProps as DSTagProps } from '@digdir/design-system-react';
+
+export enum ChangeRequestStatusColors {
+  OPEN = 'warning',
+  REJECTED = 'danger',
+  ACCEPTED = 'success',
+}
+
+export type StatusKey = keyof typeof ChangeRequestStatusColors;
+
+export type ChangeRequestStatusTagProps = {
+  statusKey: StatusKey;
+  statusLabel: string;
+} & DSTagProps;
+
+const getColorFromStatusKey = (statusKey: StatusKey | undefined) =>
+  statusKey ? ChangeRequestStatusColors[statusKey.toLocaleUpperCase() as StatusKey] : 'neutral';
+
+export const ChangeRequestStatusTag = ({
+  children,
+  statusKey,
+  statusLabel,
+  size = 'medium',
+  ...rest
+}: ChangeRequestStatusTagProps) => {
+  return (
+    <DSTag
+      color={getColorFromStatusKey(statusKey)}
+      size={size}
+      {...rest}
+    >
+      {statusLabel}
+    </DSTag>
+  );
+};
+
+ChangeRequestStatusTag.displayName = '';

--- a/libs/ui/src/lib/tag/concept-status/ConceptStatus.tsx
+++ b/libs/ui/src/lib/tag/concept-status/ConceptStatus.tsx
@@ -1,0 +1,40 @@
+import { Tag as DSTag, type TagProps as DSTagProps } from '@digdir/design-system-react';
+
+enum ConceptStatusColors {
+  DRAFT = 'second',
+  CANDIDATE = 'info',
+  WAITING = 'neutral',
+  CURRENT = 'success',
+  RETIRED = 'danger',
+  REJECTED = 'neutral',
+}
+
+export type StatusKey = keyof typeof ConceptStatusColors;
+
+export type ConceptStatusTagProps = {
+  statusKey: StatusKey;
+  statusLabel: string;
+} & DSTagProps;
+
+const getColorFromStatusKey = (statusKey: StatusKey | undefined) =>
+  statusKey ? ConceptStatusColors[statusKey.toLocaleUpperCase() as StatusKey] : 'neutral';
+
+export const ConceptStatusTag = ({
+  children,
+  statusKey,
+  statusLabel,
+  size = 'medium',
+  ...rest
+}: ConceptStatusTagProps) => {
+  return (
+    <DSTag
+      color={getColorFromStatusKey(statusKey)}
+      size={size}
+      {...rest}
+    >
+      {statusLabel}
+    </DSTag>
+  );
+};
+
+ConceptStatusTag.displayName = '';

--- a/libs/ui/src/lib/tag/index.tsx
+++ b/libs/ui/src/lib/tag/index.tsx
@@ -1,0 +1,25 @@
+import { ConceptStatusTag as TagConceptStatus, type ConceptStatusTagProps } from './concept-status/ConceptStatus';
+import {
+  ChangeRequestStatusTag as TagChangeRequestStatus,
+  type ChangeRequestStatusTagProps,
+} from './change-request-status/ChangeRequestStatus';
+import { ServiceStatusTag as TagServiceStatus, type ServiceStatusTagProps } from './service-status/ServiceStatus';
+
+type TagComponent = {
+  ConceptStatus: typeof TagConceptStatus;
+  ServiceStatus: typeof TagServiceStatus;
+  ChangeRequestStatus: typeof TagChangeRequestStatus;
+};
+
+const Tag: TagComponent = {
+  ConceptStatus: TagConceptStatus,
+  ServiceStatus: TagServiceStatus,
+  ChangeRequestStatus: TagChangeRequestStatus,
+};
+
+Tag.ConceptStatus.displayName = `Tag.ConceptStatus`;
+Tag.ChangeRequestStatus.displayName = `Tag.ChangeRequestStatus`;
+Tag.ServiceStatus.displayName = 'Tag.ServiceStatus';
+
+export type { ConceptStatusTagProps, ChangeRequestStatusTagProps, ServiceStatusTagProps };
+export { Tag, TagConceptStatus, TagChangeRequestStatus };

--- a/libs/ui/src/lib/tag/service-status/ServiceStatus.tsx
+++ b/libs/ui/src/lib/tag/service-status/ServiceStatus.tsx
@@ -1,0 +1,38 @@
+import { Tag as DSTag, type TagProps as DSTagProps } from '@digdir/design-system-react';
+
+export enum ServiceStatusColors {
+  COMPLETED = 'success',
+  DEPRECATED = 'second',
+  UNDERDEVELOPMENT = 'info',
+  WITHDRAWN = 'danger',
+}
+
+export type StatusKey = keyof typeof ServiceStatusColors;
+
+export type ServiceStatusTagProps = {
+  statusKey: StatusKey;
+  statusLabel: string;
+} & DSTagProps;
+
+const getColorFromStatusKey = (statusKey: StatusKey | undefined) =>
+  statusKey ? ServiceStatusColors[statusKey.toLocaleUpperCase() as StatusKey] : 'neutral';
+
+export const ServiceStatusTag = ({
+  children,
+  statusKey,
+  statusLabel,
+  size = 'medium',
+  ...rest
+}: ServiceStatusTagProps) => {
+  return (
+    <DSTag
+      color={getColorFromStatusKey(statusKey)}
+      size={size}
+      {...rest}
+    >
+      {statusLabel}
+    </DSTag>
+  );
+};
+
+ServiceStatusTag.displayName = '';

--- a/libs/utils/src/lib/functions/index.ts
+++ b/libs/utils/src/lib/functions/index.ts
@@ -1,5 +1,3 @@
-import { localization } from '../language/localization';
-
 /**
  * Generally used to produce a uniq hash array items.
  * Unlike uniqId() of lodash, it garanties that an array
@@ -18,13 +16,3 @@ export const isObjectNullUndefinedEmpty = (object: any | null | undefined) =>
   object === null ||
   Object.keys(object).length === 0 ||
   Object.values(object).every((x) => x === null || x === '');
-
-/**
- * Returns the color variant associated with a given concept status.
- * @param status - The status value.
- * @returns The color variant associated with the status, or 'neutral' if no match is found.
- */
-export const getTagColorVariant = (status: string | undefined) =>
-  status
-    ? Object.entries(localization.concept.statusColors as Record<string, string>).find(([key]) => key === status)?.[1]
-    : 'neutral';


### PR DESCRIPTION
resolves https://github.com/Informasjonsforvaltning/catalog-frontend/issues/553

Utvider designsystemets `<Tag>` komponent i `catalog-frontend`, og lager spesialerte `<StatusTag>` for hver catalog.