### PR TITLE
fix: move last published link in concept search hit

### DIFF
--- a/apps/concept-catalog/components/concept-search-hits/index.tsx
+++ b/apps/concept-catalog/components/concept-search-hits/index.tsx
@@ -69,10 +69,9 @@ const ConceptSearchHits: React.FC<Props> = ({
             ? localization.publicationState.publishedInFDK
             : localization.publicationState.unpublished}
         </p>
-      </div>
-      <div className={styles.rowSpaceBetween}>
         {searchHit.sistPublisertId && !searchHit?.erPublisert && (
-          <div className={styles.metaData}>
+          <>
+            <p className={styles.dot}>•</p>
             <Link
               prefetch={false}
               href={
@@ -83,8 +82,10 @@ const ConceptSearchHits: React.FC<Props> = ({
             >
               {localization.searchHit.lastPublished}
             </Link>
-          </div>
+          </>
         )}
+      </div>
+      <div className={styles.rowSpaceBetween}>
         {searchHit?.assignedUser && (
           <p className={styles.greyFont}>
             {assignableUsers?.find((user) => user.id === searchHit.assignedUser)?.name ?? localization.unknown}


### PR DESCRIPTION
fixes https://github.com/Informasjonsforvaltning/catalog-frontend/issues/892

Ser nå ut som dette:
![Screenshot 2024-11-27 at 13 00 31](https://github.com/user-attachments/assets/bdf14316-f627-46e5-b605-443ad4eb4bf6)
