### PR TITLE
feat: add endpoint & documentation links to API details page

### DIFF
--- a/apps/data-service-catalog/components/data-service-form/components/costs-table.tsx
+++ b/apps/data-service-catalog/components/data-service-form/components/costs-table.tsx
@@ -216,7 +216,7 @@ const FieldModal = ({ template, type, onSuccess, currencies }: ModalProps) => {
                     : `${localization.add} ${localization.dataServiceForm.fieldLabel.costs.toLowerCase()}`}
                 </Modal.Header>
 
-                <Modal.Content>
+                <Modal.Content className={styles.modalContent}>
                   <Fieldset
                     legend={
                       <TitleWithHelpTextAndTag

--- a/apps/data-service-catalog/components/data-service-form/data-service-form.module.css
+++ b/apps/data-service-catalog/components/data-service-form/data-service-form.module.css
@@ -61,3 +61,14 @@
     background-color: inherit;
   }
 }
+
+.modalContent {
+  margin: var(--fds-spacing-8);
+  padding: var(--fds-spacing-8);
+  border: 1px solid var(--fds-semantic-border-neutral-subtle);
+  border-radius: var(--fds-border_radius-medium);
+  height: calc(100vh - 400px);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}

--- a/apps/data-service-catalog/components/details-page-columns/components/details-url-list.tsx
+++ b/apps/data-service-catalog/components/details-page-columns/components/details-url-list.tsx
@@ -1,0 +1,22 @@
+import { List } from '@digdir/designsystemet-react';
+
+type Props = {
+  urls: string[] | undefined;
+};
+
+export const DetailsUrlList = ({ urls }: Props) => {
+  return (
+    <List.Root size={'sm'}>
+      <List.Unordered
+        style={{
+          listStyle: 'none',
+          paddingLeft: 0,
+        }}
+      >
+        {urls?.map((item, index) => {
+          return item ? <List.Item key={`urls-${index}`}>{item}</List.Item> : null;
+        })}
+      </List.Unordered>
+    </List.Root>
+  );
+};

--- a/apps/data-service-catalog/components/details-page-columns/details-page-left-column.tsx
+++ b/apps/data-service-catalog/components/details-page-columns/details-page-left-column.tsx
@@ -3,7 +3,8 @@ import styles from './details-columns.module.css';
 import { InfoCard } from '@catalog-frontend/ui';
 import { isEmpty } from 'lodash';
 import { getTranslateText, localization } from '@catalog-frontend/utils';
-import { Paragraph, Tag } from '@digdir/designsystemet-react';
+import { List, Paragraph, Tag } from '@digdir/designsystemet-react';
+import { DetailsUrlList } from './components/details-url-list';
 
 type Props = {
   dataService: DataService;
@@ -15,9 +16,10 @@ export const LeftColumn = ({ dataService, language }: Props) => {
     <InfoCard>
       {!isEmpty(dataService?.description) && (
         <InfoCard.Item title={localization.dataServiceForm.fieldLabel.description}>
-          <Paragraph size='sm'>{getTranslateText(dataService?.description, language)} </Paragraph>
+          <Paragraph size='sm'>{getTranslateText(dataService?.description, language)}</Paragraph>
         </InfoCard.Item>
       )}
+
       {!isEmpty(dataService?.keywords) && (
         <InfoCard.Item title={localization.dataServiceForm.fieldLabel.keywords}>
           <li className={styles.list}>
@@ -33,6 +35,30 @@ export const LeftColumn = ({ dataService, language }: Props) => {
               ) : null;
             })}
           </li>
+        </InfoCard.Item>
+      )}
+
+      {!isEmpty(dataService?.endpointUrl) && (
+        <InfoCard.Item title={localization.dataServiceForm.fieldLabel.endpoint}>
+          {dataService?.endpointUrl}
+        </InfoCard.Item>
+      )}
+
+      {!isEmpty(dataService?.endpointDescriptions) && (
+        <InfoCard.Item title={localization.dataServiceForm.fieldLabel.endpointDescriptions}>
+          <DetailsUrlList urls={dataService.endpointDescriptions} />
+        </InfoCard.Item>
+      )}
+
+      {!isEmpty(dataService?.landingPage) && (
+        <InfoCard.Item title={localization.dataServiceForm.fieldLabel.landingPage}>
+          {dataService?.landingPage}
+        </InfoCard.Item>
+      )}
+
+      {!isEmpty(dataService?.pages) && (
+        <InfoCard.Item title={localization.dataServiceForm.fieldLabel.pages}>
+          <DetailsUrlList urls={dataService.pages} />
         </InfoCard.Item>
       )}
     </InfoCard>


### PR DESCRIPTION
resolve #1003 
resolve #1004 

Slenger med et bilde av hvordan det nå ser ut. Usikker på om jeg burde legge det til som linker eller ikke, men landa på å kjøre enkleste løsning nå og tar det opp med kjersti og kurt stian senere

<img width="316" alt="Screenshot 2025-02-21 at 10 53 21" src="https://github.com/user-attachments/assets/c37b73e0-8e29-494b-a177-6acbe65ccab5" />
