### PR TITLE
fix: rm from array when deleting type UriWithLabel in dataset-catalog

### DIFF
--- a/apps/dataset-catalog/components/dataset-form/components/access-rights.tsx/access-rights-uri-table.tsx
+++ b/apps/dataset-catalog/components/dataset-form/components/access-rights.tsx/access-rights-uri-table.tsx
@@ -18,7 +18,7 @@ import { Button, Fieldset, Modal, Radio, Table, Textfield } from '@digdir/design
 import { FastField, Formik, useFormikContext } from 'formik';
 import styles from '../../dataset-form.module.css';
 import { useRef, useState } from 'react';
-import _ from 'lodash';
+import { identity, isEmpty, pickBy, trim } from 'lodash';
 import { uriWithLabelSchema } from '../../utils/validation-schema';
 
 type LegalBasis = {
@@ -35,7 +35,7 @@ type ModalProps = {
 
 const hasNoFieldValues = (values: UriWithLabel) => {
   if (!values) return true;
-  return _.isEmpty(_.trim(values.uri)) && _.isEmpty(_.pickBy(values.prefLabel, _.identity));
+  return isEmpty(trim(values.uri)) && isEmpty(pickBy(values.prefLabel, identity));
 };
 
 const accessRightTypes = ['legalBasisForRestriction', 'legalBasisForProcessing', 'legalBasisForAccess'];

--- a/apps/dataset-catalog/components/dataset-form/components/details-section/hidden-detail-fields.tsx
+++ b/apps/dataset-catalog/components/dataset-form/components/details-section/hidden-detail-fields.tsx
@@ -17,7 +17,7 @@ import FieldsetWithDelete from '../../../fieldset-with-delete';
 import { ToggleFieldButton } from '../toggle-field-button';
 import { UriWithLabelFieldsetTable } from '../uri-with-label-field-set-table';
 import { useEffect, useMemo, useRef, useState } from 'react';
-import _ from 'lodash';
+import { isEmpty } from 'lodash';
 import React from 'react';
 
 type Props = {
@@ -255,7 +255,7 @@ export const HiddenDetailFields = ({ datasetTypes, provenanceStatements, frequen
         values={values.conformsTo}
         fieldName={'conformsTo'}
         label={
-          !_.isEmpty(values.conformsTo) && (
+          !isEmpty(values.conformsTo) && (
             <TitleWithHelpTextAndTag helpText={localization.datasetForm.helptext.conformsTo}>
               {localization.datasetForm.fieldLabel.conformsTo}
             </TitleWithHelpTextAndTag>

--- a/apps/dataset-catalog/components/dataset-form/components/details-section/hidden-detail-fields.tsx
+++ b/apps/dataset-catalog/components/dataset-form/components/details-section/hidden-detail-fields.tsx
@@ -255,8 +255,7 @@ export const HiddenDetailFields = ({ datasetTypes, provenanceStatements, frequen
         values={values.conformsTo}
         fieldName={'conformsTo'}
         label={
-          !_.isEmpty(values.conformsTo) &&
-          _.some(values.conformsTo, (item) => !_.isUndefined(item)) && (
+          !_.isEmpty(values.conformsTo) && (
             <TitleWithHelpTextAndTag helpText={localization.datasetForm.helptext.conformsTo}>
               {localization.datasetForm.fieldLabel.conformsTo}
             </TitleWithHelpTextAndTag>

--- a/apps/dataset-catalog/components/dataset-form/components/details-section/temporal-modal.tsx
+++ b/apps/dataset-catalog/components/dataset-form/components/details-section/temporal-modal.tsx
@@ -5,7 +5,7 @@ import { Button, Modal, Table, Textfield } from '@digdir/designsystemet-react';
 import { FastField, Formik, useFormikContext } from 'formik';
 import styles from '../../dataset-form.module.css';
 import { ReactNode, useRef, useState } from 'react';
-import _ from 'lodash';
+import { isEmpty } from 'lodash';
 import { dateSchema } from '../../utils/validation-schema';
 import cn from 'classnames';
 import { MinusIcon } from '@navikt/aksel-icons';
@@ -23,7 +23,7 @@ interface ModalProps {
 
 const hasNoFieldValues = (values: DateRange) => {
   if (!values) return true;
-  return _.isEmpty(values.startDate) && _.isEmpty(values.endDate);
+  return isEmpty(values.startDate) && isEmpty(values.endDate);
 };
 
 export const TemporalModal = ({ values, label }: Props) => {

--- a/apps/dataset-catalog/components/dataset-form/components/relations-section/references-table.tsx
+++ b/apps/dataset-catalog/components/dataset-form/components/relations-section/references-table.tsx
@@ -7,7 +7,7 @@ import relations from '../../utils/relations.json';
 import { AddButton, DeleteButton, EditButton, TitleWithHelpTextAndTag } from '@catalog-frontend/ui';
 import { useState, useRef } from 'react';
 import { referenceSchema } from '../../utils/validation-schema';
-import _ from 'lodash';
+import { compact, isEmpty } from 'lodash';
 import styles from '../../dataset-form.module.css';
 import cn from 'classnames';
 
@@ -25,7 +25,7 @@ type ModalProps = {
 
 const hasNoFieldValues = (values: Reference) => {
   if (!values) return true;
-  return _.isEmpty(values?.referenceType?.code) && _.isEmpty(values?.source?.uri);
+  return isEmpty(values?.referenceType?.code) && isEmpty(values?.source?.uri);
 };
 
 export const ReferenceTable = ({ searchEnv }: Props) => {
@@ -42,7 +42,7 @@ export const ReferenceTable = ({ searchEnv }: Props) => {
       <TitleWithHelpTextAndTag helpText={localization.datasetForm.helptext.references}>
         {localization.datasetForm.fieldLabel.references}
       </TitleWithHelpTextAndTag>
-      {values?.references && _.compact(values?.references).length > 0 && (
+      {values?.references && compact(values?.references).length > 0 && (
         <Table
           size='sm'
           className={styles.table}

--- a/apps/dataset-catalog/components/dataset-form/components/toggle-field-button.tsx
+++ b/apps/dataset-catalog/components/dataset-form/components/toggle-field-button.tsx
@@ -5,7 +5,7 @@ import { useFormikContext } from 'formik';
 import { PropsWithChildren, useMemo } from 'react';
 import FieldsetWithDelete from '../../fieldset-with-delete';
 import styles from '../dataset-form.module.css';
-import _ from 'lodash';
+import { isArray, isEmpty, isNil, isObject } from 'lodash';
 import { Box } from '@digdir/designsystemet-react';
 
 type Props = {
@@ -29,13 +29,13 @@ export const ToggleFieldButton = ({
   const { setFieldValue } = useFormikContext<Dataset>();
 
   const shouldShowField = useMemo(() => {
-    if (fieldName === 'qualifiedAttributions' && _.isArray(fieldValues) && fieldValues.length === 0) {
+    if (fieldName === 'qualifiedAttributions' && isArray(fieldValues) && fieldValues.length === 0) {
       return true;
     }
 
-    if (_.isArray(fieldValues)) return fieldValues.length > 0;
-    if (_.isObject(fieldValues)) return !_.isEmpty(fieldValues);
-    return !_.isNil(fieldValues);
+    if (isArray(fieldValues)) return fieldValues.length > 0;
+    if (isObject(fieldValues)) return !isEmpty(fieldValues);
+    return !isNil(fieldValues);
   }, [fieldValues, fieldName]);
 
   const handleDelete = () => {

--- a/apps/dataset-catalog/components/dataset-form/components/uri-with-label-field-set-table.tsx
+++ b/apps/dataset-catalog/components/dataset-form/components/uri-with-label-field-set-table.tsx
@@ -9,7 +9,7 @@ import {
 } from '@catalog-frontend/ui';
 import { getTranslateText, localization, trimObjectWhitespace } from '@catalog-frontend/utils';
 import { Button, Modal, Table, Textfield } from '@digdir/designsystemet-react';
-import { FastField, Formik, useFormikContext } from 'formik';
+import { FastField, FieldArray, Formik } from 'formik';
 import styles from '../dataset-form.module.css';
 import { ReactNode, useRef, useState } from 'react';
 import { trim, isEmpty, pickBy, identity } from 'lodash';
@@ -34,62 +34,55 @@ const hasNoFieldValues = (values: UriWithLabel) => {
 };
 
 export const UriWithLabelFieldsetTable = ({ fieldName, values, label }: Props) => {
-  const { setFieldValue } = useFormikContext();
-
-  function removeAtIndex(arr: UriWithLabel[], index: number) {
-    arr.splice(index, 1);
-    return arr;
-  }
-
   return (
     <div className={styles.fieldContainer}>
       {typeof label === 'string' ? <FormHeading>{label}</FormHeading> : label}
-      {values && values?.length > 0 && (
-        <Table
-          size='sm'
-          className={styles.table}
-        >
-          <Table.Head>
-            <Table.Row>
-              <Table.HeaderCell>{localization.title}</Table.HeaderCell>
-              <Table.HeaderCell>{localization.link}</Table.HeaderCell>
-              <Table.HeaderCell aria-label='Actions' />
-            </Table.Row>
-          </Table.Head>
-          <Table.Body>
-            {values?.map((item, index) => (
-              <Table.Row key={`${fieldName}-tableRow-${index}`}>
-                <Table.Cell>{getTranslateText(item?.prefLabel)}</Table.Cell>
-                <Table.Cell>{item?.uri}</Table.Cell>
-                <Table.Cell>
-                  <span className={styles.set}>
-                    <FieldModal
-                      fieldName={fieldName}
-                      template={item}
-                      type={'edit'}
-                      onSuccess={(updatedItem: UriWithLabel) => setFieldValue(`${fieldName}[${index}]`, updatedItem)}
-                    />
-                    <DeleteButton onClick={() => setFieldValue(fieldName, removeAtIndex(values, index))} />
-                  </span>
-                </Table.Cell>
-              </Table.Row>
-            ))}
-          </Table.Body>
-        </Table>
-      )}
-      <div>
-        <FieldModal
-          fieldName={fieldName}
-          template={{ prefLabel: { nb: '' }, uri: '' }}
-          type={'new'}
-          onSuccess={(formValues) =>
-            setFieldValue(
-              values && values?.length > 0 ? `${fieldName}[${values?.length}]` : `${fieldName}[0]`,
-              formValues,
-            )
-          }
-        />
-      </div>
+      <FieldArray
+        name={fieldName}
+        render={(arrayHelpers) => (
+          <>
+            <Table
+              size='sm'
+              className={styles.table}
+            >
+              <Table.Head>
+                <Table.Row>
+                  <Table.HeaderCell>{localization.title}</Table.HeaderCell>
+                  <Table.HeaderCell>{localization.link}</Table.HeaderCell>
+                  <Table.HeaderCell aria-label='Actions' />
+                </Table.Row>
+              </Table.Head>
+              <Table.Body>
+                {values?.map((item, index) => (
+                  <Table.Row key={`${fieldName}-tableRow-${index}`}>
+                    <Table.Cell>{getTranslateText(item?.prefLabel)}</Table.Cell>
+                    <Table.Cell>{item?.uri}</Table.Cell>
+                    <Table.Cell>
+                      <span className={styles.set}>
+                        <FieldModal
+                          fieldName={fieldName}
+                          template={item}
+                          type={'edit'}
+                          onSuccess={(updatedItem: UriWithLabel) => arrayHelpers.replace(index, updatedItem)}
+                        />
+                        <DeleteButton onClick={() => arrayHelpers.remove(index)} />
+                      </span>
+                    </Table.Cell>
+                  </Table.Row>
+                ))}
+              </Table.Body>
+            </Table>
+            <div>
+              <FieldModal
+                fieldName={fieldName}
+                template={{ prefLabel: { nb: '' }, uri: '' }}
+                type={'new'}
+                onSuccess={(formValues) => arrayHelpers.push(formValues)}
+              />
+            </div>
+          </>
+        )}
+      />
     </div>
   );
 };

--- a/apps/dataset-catalog/components/dataset-form/components/uri-with-label-field-set-table.tsx
+++ b/apps/dataset-catalog/components/dataset-form/components/uri-with-label-field-set-table.tsx
@@ -36,10 +36,15 @@ const hasNoFieldValues = (values: UriWithLabel) => {
 export const UriWithLabelFieldsetTable = ({ fieldName, values, label }: Props) => {
   const { setFieldValue } = useFormikContext();
 
+  function removeAtIndex(arr: UriWithLabel[], index: number) {
+    arr.splice(index, 1);
+    return arr;
+  }
+
   return (
     <div className={styles.fieldContainer}>
       {typeof label === 'string' ? <FormHeading>{label}</FormHeading> : label}
-      {values && values?.length > 0 && !hasNoFieldValues(values[0]) && (
+      {values && values?.length > 0 && (
         <Table
           size='sm'
           className={styles.table}
@@ -64,7 +69,7 @@ export const UriWithLabelFieldsetTable = ({ fieldName, values, label }: Props) =
                       type={'edit'}
                       onSuccess={(updatedItem: UriWithLabel) => setFieldValue(`${fieldName}[${index}]`, updatedItem)}
                     />
-                    <DeleteButton onClick={() => setFieldValue(`${fieldName}[${index}]`, undefined)} />
+                    <DeleteButton onClick={() => setFieldValue(fieldName, removeAtIndex(values, index))} />
                   </span>
                 </Table.Cell>
               </Table.Row>
@@ -79,9 +84,7 @@ export const UriWithLabelFieldsetTable = ({ fieldName, values, label }: Props) =
           type={'new'}
           onSuccess={(formValues) =>
             setFieldValue(
-              values && values?.length > 0 && !hasNoFieldValues(values[0])
-                ? `${fieldName}[${values?.length}]`
-                : `${fieldName}[0]`,
+              values && values?.length > 0 ? `${fieldName}[${values?.length}]` : `${fieldName}[0]`,
               formValues,
             )
           }

--- a/apps/dataset-catalog/components/dataset-form/utils/dataset-initial-values.tsx
+++ b/apps/dataset-catalog/components/dataset-form/utils/dataset-initial-values.tsx
@@ -1,6 +1,6 @@
 import { Dataset, DatasetToBeCreated, Distribution, PublicationStatus } from '@catalog-frontend/types';
 import { groupByKeys } from '@catalog-frontend/utils';
-import _ from 'lodash';
+import { isEmpty } from 'lodash';
 
 export const datasetTemplate = (dataset: Dataset): Dataset => {
   return {
@@ -8,7 +8,7 @@ export const datasetTemplate = (dataset: Dataset): Dataset => {
     catalogId: dataset?.catalogId ?? '',
     _lastModified: dataset?._lastModified,
     title: dataset.title ?? '',
-    description: !_.isEmpty(dataset?.description) ? dataset.description : { nb: '' },
+    description: !isEmpty(dataset?.description) ? dataset.description : { nb: '' },
     accessRights: { uri: dataset?.accessRights?.uri ?? 'none' },
     legalBasisForAccess: dataset?.legalBasisForAccess ?? [],
     legalBasisForProcessing: dataset?.legalBasisForProcessing ?? [],
@@ -102,7 +102,7 @@ export const distributionTemplate = (dist: Distribution | undefined) => {
         ...dist,
         title: dist?.title ?? { nb: '' },
         downloadURL: dist?.downloadURL && dist?.downloadURL[0] ? dist?.downloadURL : [''],
-        conformsTo: !_.isEmpty(dist.conformsTo) ? dist.conformsTo : [{ uri: '', prefLabel: { nb: '' } }],
+        conformsTo: !isEmpty(dist.conformsTo) ? dist.conformsTo : [{ uri: '', prefLabel: { nb: '' } }],
       }
     : {
         title: { nb: '' },

--- a/apps/dataset-catalog/components/details-page-columns/components/access-rights-details.tsx
+++ b/apps/dataset-catalog/components/details-page-columns/components/access-rights-details.tsx
@@ -3,7 +3,7 @@ import { accessRightPublic, accessRights, getTranslateText, localization } from 
 import { Card, Table, Tag } from '@digdir/designsystemet-react';
 import { useMemo } from 'react';
 import styles from '../details-columns.module.css';
-import _ from 'lodash';
+import { identity, isEmpty, pickBy, trim } from 'lodash';
 
 type Props = {
   dataset: Dataset;
@@ -12,9 +12,7 @@ type Props = {
 
 const hasNoFieldValues = (values: UriWithLabel) => {
   if (!values) return true;
-  return (
-    _.isEmpty(_.trim(values.uri)) && (_.isEmpty(values.prefLabel) || _.isEmpty(_.pickBy(values.prefLabel, _.identity)))
-  );
+  return isEmpty(trim(values.uri)) && (isEmpty(values.prefLabel) || isEmpty(pickBy(values.prefLabel, identity)));
 };
 
 export const AccessRightsDetails = ({ dataset, language }: Props) => {

--- a/apps/dataset-catalog/components/details-page-columns/components/distribution-details.tsx
+++ b/apps/dataset-catalog/components/details-page-columns/components/distribution-details.tsx
@@ -4,7 +4,7 @@ import { Card, Heading, Tag } from '@digdir/designsystemet-react';
 import { DistributionDetails } from '../../dataset-form/components/distribution-section/distribution-details';
 import styles from '../details-columns.module.css';
 import { useSearchFileTypeByUri } from '../../../hooks/useReferenceDataSearch';
-import _ from 'lodash';
+import { isEmpty } from 'lodash';
 
 type Props = {
   distribution: Partial<Distribution>;
@@ -26,7 +26,7 @@ export const DistributionDetailsCard = ({
   return (
     <Card>
       <div className={styles.infoCardItems}>
-        {distribution?.title && !_.isEmpty(distribution?.title) && (
+        {distribution?.title && !isEmpty(distribution?.title) && (
           <div>
             <Heading
               level={4}
@@ -50,7 +50,7 @@ export const DistributionDetailsCard = ({
           </div>
         )}
 
-        {distribution?.format && !_.isEmpty(distribution.format) && (
+        {distribution?.format && !isEmpty(distribution.format) && (
           <div>
             <Heading
               level={4}

--- a/apps/dataset-catalog/components/details-page-columns/details-page-left-column.tsx
+++ b/apps/dataset-catalog/components/details-page-columns/details-page-left-column.tsx
@@ -24,7 +24,7 @@ import { DistributionDetailsCard } from './components/distribution-details';
 import { AccessRightsDetails } from './components/access-rights-details';
 import { TemporalDetails } from './components/temporal-details';
 import TagList from '../tag-list';
-import _ from 'lodash';
+import { compact, isEmpty } from 'lodash';
 import Markdown from 'react-markdown';
 
 type Props = {
@@ -61,7 +61,7 @@ export const LeftColumn = ({ dataset, referenceDataEnv, searchEnv, referenceData
   );
 
   const hasValues = (values: any | any[] | undefined | null): boolean => {
-    return values && !_.isEmpty(values);
+    return values && !isEmpty(values);
   };
 
   const getDataNorgeUri = (id: string | undefined, resourceType: Search.ResourceType) => {
@@ -182,7 +182,7 @@ export const LeftColumn = ({ dataset, referenceDataEnv, searchEnv, referenceData
         </InfoCard.Item>
       )}
 
-      {dataset?.landingPage && !_.isEmpty(dataset?.landingPage[0]) && (
+      {dataset?.landingPage && !isEmpty(dataset?.landingPage[0]) && (
         <InfoCard.Item title={localization.datasetForm.fieldLabel.landingPage}>
           <div className={styles.infoCardItems}>
             {dataset?.landingPage.map((item) => <Paragraph key={item}>{item}</Paragraph>)}
@@ -190,7 +190,7 @@ export const LeftColumn = ({ dataset, referenceDataEnv, searchEnv, referenceData
         </InfoCard.Item>
       )}
 
-      {dataset?.temporal && !_.isEmpty(dataset?.temporal[0]) && (
+      {dataset?.temporal && !isEmpty(dataset?.temporal[0]) && (
         <InfoCard.Item title={localization.datasetForm.fieldLabel.temporal}>
           <TemporalDetails temporal={dataset?.temporal} />
         </InfoCard.Item>
@@ -294,7 +294,7 @@ export const LeftColumn = ({ dataset, referenceDataEnv, searchEnv, referenceData
       {(hasValues(dataset.references) || hasValues(dataset.relations)) && (
         <InfoCard.Item title={localization.relations}>
           <div className={styles.infoCardItems}>
-            {dataset?.references && _.compact(dataset?.references).length > 0 && (
+            {dataset?.references && compact(dataset?.references).length > 0 && (
               <Table
                 size='sm'
                 className={styles.table}
@@ -412,7 +412,7 @@ export const LeftColumn = ({ dataset, referenceDataEnv, searchEnv, referenceData
           </Table>
         </InfoCard.Item>
       )}
-      {dataset?.keyword && !_.isEmpty(dataset?.keyword[0]) && (
+      {dataset?.keyword && !isEmpty(dataset?.keyword[0]) && (
         <InfoCard.Item title={localization.datasetForm.fieldLabel.keyword}>
           <li className={styles.list}>
             {dataset.keyword?.map((item, index) => {
@@ -464,7 +464,7 @@ export const LeftColumn = ({ dataset, referenceDataEnv, searchEnv, referenceData
         </InfoCard.Item>
       )}
 
-      {dataset?.informationModel && !_.isEmpty(dataset?.informationModel[0]?.uri) && (
+      {dataset?.informationModel && !isEmpty(dataset?.informationModel[0]?.uri) && (
         <InfoCard.Item title={localization.datasetForm.fieldLabel.informationModel}>
           <UriWithLabelTable
             values={dataset?.informationModel}

--- a/apps/dataset-catalog/components/details-page-columns/details-page-left-column.tsx
+++ b/apps/dataset-catalog/components/details-page-columns/details-page-left-column.tsx
@@ -80,7 +80,10 @@ export const LeftColumn = ({ dataset, referenceDataEnv, searchEnv, referenceData
           title={localization.access}
           className={styles.access}
         >
-          <AccessRightsDetails dataset={dataset} language={language} />
+          <AccessRightsDetails
+            dataset={dataset}
+            language={language}
+          />
         </InfoCard.Item>
       )}
 
@@ -243,7 +246,7 @@ export const LeftColumn = ({ dataset, referenceDataEnv, searchEnv, referenceData
         </InfoCard.Item>
       )}
 
-      {dataset?.conformsTo && dataset?.conformsTo[0]?.uri && (
+      {dataset?.conformsTo && (
         <InfoCard.Item title={localization.datasetForm.fieldLabel.conformsTo}>
           <UriWithLabelTable
             values={dataset?.conformsTo}

--- a/apps/dataset-catalog/components/details-page-columns/details-page-right-column.tsx
+++ b/apps/dataset-catalog/components/details-page-columns/details-page-right-column.tsx
@@ -1,7 +1,7 @@
 import { InfoCard } from '@catalog-frontend/ui';
-import { capitalizeFirstLetter, formatISO, localization } from '@catalog-frontend/utils';
+import { localization } from '@catalog-frontend/utils';
 import { EnvelopeClosedIcon, PhoneIcon, LinkIcon } from '@navikt/aksel-icons';
-import _ from 'lodash';
+import { isEmpty } from 'lodash';
 import PublishSwitch from '../publish-switch';
 import { Dataset, PublicationStatus } from '@catalog-frontend/types';
 import styles from './details-columns.module.css';
@@ -44,7 +44,7 @@ export const RightColumn = ({ dataset, hasWritePermission }: Props) => {
         {published ? localization.publicationState.publishedInFDK : localization.publicationState.unpublished}
       </InfoCard.Item>
 
-      {dataset?.contactPoint && !_.isEmpty(dataset?.contactPoint[0]) && (
+      {dataset?.contactPoint && !isEmpty(dataset?.contactPoint[0]) && (
         <InfoCard.Item
           title={localization.concept.contactInformation}
           headingColor='light'

--- a/apps/dataset-catalog/components/uri-with-label-table/index.tsx
+++ b/apps/dataset-catalog/components/uri-with-label-table/index.tsx
@@ -23,9 +23,9 @@ export const UriWithLabelTable = ({ values = [], language }: Props) => {
       </Table.Head>
       <Table.Body>
         {values.map((item, index) => (
-          <Table.Row key={`uri-with-label-table-${item.uri}-${index}`}>
-            <Table.Cell>{getTranslateText(item.prefLabel, language)}</Table.Cell>
-            <Table.Cell>{item.uri}</Table.Cell>
+          <Table.Row key={`uri-with-label-table-${item?.uri}-${index}`}>
+            <Table.Cell>{getTranslateText(item?.prefLabel, language)}</Table.Cell>
+            <Table.Cell>{item?.uri}</Table.Cell>
           </Table.Row>
         ))}
       </Table.Body>


### PR DESCRIPTION
resolve #1147 

Dette var også et problem for feltene `relations` og `informationModel`

Elementer i disse listene ble satt til undefined, men ikke fjernet, når de ble slettet.