### PR TITLE
feat: show publisher when adding dataset relation & access service

### DIFF
--- a/apps/dataset-catalog/components/dataset-form/components/distribution-section/distribution-modal.tsx
+++ b/apps/dataset-catalog/components/dataset-form/components/distribution-section/distribution-modal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { DataService, Distribution, ReferenceDataCode } from '@catalog-frontend/types';
+import { Distribution, ReferenceDataCode } from '@catalog-frontend/types';
 import {
   AddButton,
   DeleteButton,
@@ -207,8 +207,16 @@ export const DistributionModal = ({
                                 <Combobox.Option
                                   key={`distribution-${option.uri}-${i}`}
                                   value={option.uri ?? option.description}
+                                  displayValue={(getTranslateText(option.title) as string) ?? option.uri}
                                 >
-                                  {option.title ? getTranslateText(option.title) : getTranslateText(option.description)}
+                                  <div className={styles.comboboxOptionTwoColumns}>
+                                    <div>
+                                      {option.title
+                                        ? getTranslateText(option.title)
+                                        : getTranslateText(option.description)}
+                                    </div>
+                                    <div>{getTranslateText(option.organization?.prefLabel) ?? ''}</div>
+                                  </div>
                                 </Combobox.Option>
                               ))}
                             </Combobox>

--- a/apps/dataset-catalog/components/dataset-form/components/distribution-section/distributions.module.scss
+++ b/apps/dataset-catalog/components/dataset-form/components/distribution-section/distributions.module.scss
@@ -87,3 +87,9 @@
 .table td {
   word-wrap: break-word;
 }
+
+.comboboxOptionTwoColumns {
+  display: grid;
+  grid-template-columns: 49% 49%;
+  gap: 2%;
+}

--- a/apps/dataset-catalog/components/dataset-form/components/relations-section/references-table.tsx
+++ b/apps/dataset-catalog/components/dataset-form/components/relations-section/references-table.tsx
@@ -205,8 +205,12 @@ const FieldModal = ({ template, type, onSuccess, searchEnv, selectedUri }: Modal
                       <Combobox.Option
                         key={dataset.uri}
                         value={dataset.uri}
+                        displayValue={(getTranslateText(dataset.title) as string) ?? dataset.uri}
                       >
-                        {dataset?.title ? getTranslateText(dataset?.title) : dataset.uri}
+                        <div className={styles.comboboxOptionTwoColumns}>
+                          <div>{dataset?.title ? getTranslateText(dataset?.title) : dataset.uri}</div>
+                          <div>{getTranslateText(dataset.organization?.prefLabel) ?? ''}</div>
+                        </div>
                       </Combobox.Option>
                     ))}
                   </Combobox>

--- a/apps/dataset-catalog/components/dataset-form/dataset-form.module.css
+++ b/apps/dataset-catalog/components/dataset-form/dataset-form.module.css
@@ -49,6 +49,12 @@
   gap: 2.5%;
 }
 
+.comboboxOptionTwoColumns {
+  display: grid;
+  grid-template-columns: 49% 49%;
+  gap: 2%;
+}
+
 .tagsButton {
   display: flex;
   align-items: flex-end;


### PR DESCRIPTION
resolve #1186 

Tok meg den friheten å fikse det samme for tilgangstjenester.

relasjoner:
<img width="667" alt="Screenshot 2025-05-26 at 07 34 25" src="https://github.com/user-attachments/assets/97faf6f7-8c04-4384-bd30-a5591128b081" />


tilgangstjenester:
<img width="935" alt="Screenshot 2025-05-26 at 07 32 51" src="https://github.com/user-attachments/assets/0e3c3e7c-7f58-4284-8b0d-d221bbc3a678" />


