### PR TITLE
fix: proper dataset error highlighting

### DIFF
--- a/apps/dataset-catalog/components/dataset-form/components/access-rights-fields.tsx
+++ b/apps/dataset-catalog/components/dataset-form/components/access-rights-fields.tsx
@@ -6,7 +6,7 @@ import { useFormikContext } from 'formik';
 import { UriWithLabelFieldsetTable } from './uri-with-label-field-set-table';
 
 export const AccessRightFields = () => {
-  const { values, setFieldValue } = useFormikContext<Dataset>();
+  const { values, errors, setFieldValue } = useFormikContext<Dataset>();
 
   return (
     <>
@@ -42,6 +42,7 @@ export const AccessRightFields = () => {
       <UriWithLabelFieldsetTable
         values={values.legalBasisForRestriction}
         fieldName={'legalBasisForRestriction'}
+        errors={errors.legalBasisForRestriction}
         hideHeadWhenEmpty={true}
         label={
           <TitleWithHelpTextAndTag
@@ -59,6 +60,7 @@ export const AccessRightFields = () => {
       <UriWithLabelFieldsetTable
         values={values.legalBasisForProcessing}
         fieldName={'legalBasisForProcessing'}
+        errors={errors.legalBasisForProcessing}
         hideHeadWhenEmpty={true}
         label={
           <TitleWithHelpTextAndTag
@@ -76,6 +78,7 @@ export const AccessRightFields = () => {
       <UriWithLabelFieldsetTable
         values={values.legalBasisForAccess}
         fieldName={'legalBasisForAccess'}
+        errors={errors.legalBasisForAccess}
         hideHeadWhenEmpty={true}
         label={
           <TitleWithHelpTextAndTag

--- a/apps/dataset-catalog/components/dataset-form/components/contact-point-section.tsx
+++ b/apps/dataset-catalog/components/dataset-form/components/contact-point-section.tsx
@@ -23,6 +23,7 @@ export const ContactPointSection = () => {
           </TitleWithHelpTextAndTag>
         }
         availableFields={contactPointOptions}
+        errorPath={'contactPoint'}
       />
     </>
   );

--- a/apps/dataset-catalog/components/dataset-form/components/details-section/minimized-detail-fields.tsx
+++ b/apps/dataset-catalog/components/dataset-form/components/details-section/minimized-detail-fields.tsx
@@ -287,7 +287,7 @@ const FIELD_CONFIG = [
       <UriWithLabelFieldsetTable
         values={props.values.conformsTo}
         fieldName={'conformsTo'}
-        expanded={props.expanded}
+        errors={props.errors.conformsTo}
         hideHeadWhenEmpty={true}
         showDivider={props.showDivider}
         label={
@@ -377,6 +377,7 @@ export const MinimizedDetailFields = ({ datasetTypes, provenanceStatements, freq
       <div key={fieldConfig.name}>
         {fieldConfig.render({
           values,
+          errors,
           setFieldValue,
           setInputRef,
           setFocus,
@@ -399,6 +400,7 @@ export const MinimizedDetailFields = ({ datasetTypes, provenanceStatements, freq
       >
         {fieldConfig.render({
           values,
+          errors,
           setFieldValue,
           ref: (el: HTMLInputElement | HTMLTextAreaElement | null) => setInputRef(fieldConfig.name, el),
           datasetTypeOptions,

--- a/apps/dataset-catalog/components/dataset-form/components/details-section/recommended-detail-fields.tsx
+++ b/apps/dataset-catalog/components/dataset-form/components/details-section/recommended-detail-fields.tsx
@@ -20,7 +20,7 @@ interface Props {
 
 export const RecommendedDetailFields = ({ referenceDataEnv, languages }: Props) => {
   const [searchTerm, setSearchTerm] = useState<string>('');
-  const { values, setFieldValue } = useFormikContext<Dataset>();
+  const { values, errors, setFieldValue } = useFormikContext<Dataset>();
   const langNOR = languages.filter((lang) => lang.code === 'NOR')[0];
 
   const { data: searchHits, isLoading: isSearching } = useSearchAdministrativeUnits(searchTerm, referenceDataEnv);
@@ -93,7 +93,7 @@ export const RecommendedDetailFields = ({ referenceDataEnv, languages }: Props) 
         }
         size='sm'
       >
-        {values.languageList && values.languageList.some(lang => lang.includes('NOR')) && (
+        {values.languageList && values.languageList.some((lang) => lang.includes('NOR')) && (
           <Checkbox
             key={langNOR.uri}
             value={langNOR.uri}
@@ -118,14 +118,17 @@ export const RecommendedDetailFields = ({ referenceDataEnv, languages }: Props) 
       <div className={styles.fieldContainer}>
         <Fieldset
           size='sm'
-          legend={<TitleWithHelpTextAndTag
-            tagColor='info'
-            tagTitle={localization.tag.recommended}
-            helpText={localization.datasetForm.helptext.spatial}
-          >
-            {localization.datasetForm.fieldLabel.spatial}
-          </TitleWithHelpTextAndTag>}>
-            <Combobox
+          legend={
+            <TitleWithHelpTextAndTag
+              tagColor='info'
+              tagTitle={localization.tag.recommended}
+              helpText={localization.datasetForm.helptext.spatial}
+            >
+              {localization.datasetForm.fieldLabel.spatial}
+            </TitleWithHelpTextAndTag>
+          }
+        >
+          <Combobox
             placeholder={`${localization.search.search}...`}
             multiple
             hideClearButton
@@ -148,11 +151,12 @@ export const RecommendedDetailFields = ({ referenceDataEnv, languages }: Props) 
               </Combobox.Option>
             ))}
           </Combobox>
-        </Fieldset>        
+        </Fieldset>
       </div>
       <FieldsetDivider />
       <TemporalModal
         values={values.temporal}
+        errors={errors}
         label={
           <TitleWithHelpTextAndTag
             tagTitle={localization.tag.recommended}

--- a/apps/dataset-catalog/components/dataset-form/components/details-section/temporal-modal.tsx
+++ b/apps/dataset-catalog/components/dataset-form/components/details-section/temporal-modal.tsx
@@ -5,7 +5,7 @@ import { Button, Modal, Table, Textfield } from '@digdir/designsystemet-react';
 import { FastField, FieldArray, Formik } from 'formik';
 import styles from '../../dataset-form.module.css';
 import { ReactNode, useRef, useState } from 'react';
-import { isEmpty } from 'lodash';
+import { get, isEmpty } from 'lodash';
 import { dateSchema } from '../../utils/validation-schema';
 import cn from 'classnames';
 import { MinusIcon } from '@navikt/aksel-icons';
@@ -13,6 +13,7 @@ import { MinusIcon } from '@navikt/aksel-icons';
 interface Props {
   values: DateRange[] | undefined;
   label?: string | ReactNode;
+  errors?: any;
 }
 
 interface ModalProps {
@@ -26,14 +27,14 @@ const hasNoFieldValues = (values: DateRange) => {
   return isEmpty(values.startDate) && isEmpty(values.endDate);
 };
 
-export const TemporalModal = ({ values, label }: Props) => {
+export const TemporalModal = ({ values, label, errors }: Props) => {
   return (
     <div className={styles.fieldContainer}>
       {typeof label === 'string' ? <FormHeading>{label}</FormHeading> : label}
       <FieldArray
         name={'temporal'}
         render={(arrayHelpers) => (
-          <>
+          <div className={get(errors, `temporal`) ? styles.errorBorder : undefined}>
             {values && values?.length > 0 && (
               <Table
                 size='sm'
@@ -73,7 +74,7 @@ export const TemporalModal = ({ values, label }: Props) => {
                 onSuccess={(formValues) => arrayHelpers.push(formValues)}
               />
             </div>
-          </>
+          </div>
         )}
       />
     </div>

--- a/apps/dataset-catalog/components/dataset-form/components/distribution-section/distribution-section.tsx
+++ b/apps/dataset-catalog/components/dataset-form/components/distribution-section/distribution-section.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { useFormikContext } from 'formik';
-import { Box, Button, Card, Heading, Paragraph, Tag } from '@digdir/designsystemet-react';
+import { Box, Button, Card, ErrorMessage, Heading, Paragraph, Tag } from '@digdir/designsystemet-react';
 import { ChevronDownIcon, ChevronUpIcon, PencilWritingIcon } from '@navikt/aksel-icons';
 import { Dataset, Distribution, ReferenceDataCode, Search } from '@catalog-frontend/types';
 import { AddButton, DeleteButton, FieldsetDivider, TitleWithHelpTextAndTag } from '@catalog-frontend/ui';
@@ -10,7 +10,7 @@ import { getTranslateText, localization } from '@catalog-frontend/utils';
 import { DistributionModal } from './distribution-modal';
 import { DistributionDetails } from './distribution-details';
 import styles from './distributions.module.scss';
-import { isEmpty } from 'lodash';
+import { get, isEmpty } from 'lodash';
 import {
   ReferenceDataGraphql,
   searchReferenceDataByUri,
@@ -24,7 +24,7 @@ type Props = {
 };
 
 export const DistributionSection = ({ referenceDataEnv, searchEnv, openLicenses }: Props) => {
-  const { values, setFieldValue } = useFormikContext<Dataset>();
+  const { values, errors, setFieldValue } = useFormikContext<Dataset>();
   const [selectedFileTypeUris, setSelectedFileTypeUris] = useState<string[]>();
   const [selectedMediaTypeUris, setSelectedMediaTypeUris] = useState<string[]>();
   const [selectedDataServiceUris, setSelectedDataServiceUris] = useState<string[]>();
@@ -273,6 +273,9 @@ export const DistributionSection = ({ referenceDataEnv, searchEnv, openLicenses 
                       openLicenses={openLicenses}
                     />
                   )}
+                  {get(errors, 'distribution[' + index + ']') && (
+                    <ErrorMessage size={'sm'}>{localization.validation.multipleInvalidValues}</ErrorMessage>
+                  )}
                 </Card>
               ),
           )}
@@ -420,6 +423,9 @@ export const DistributionSection = ({ referenceDataEnv, searchEnv, openLicenses 
                       distribution={item}
                       openLicenses={openLicenses}
                     />
+                  )}
+                  {get(errors, 'sample[' + index + ']') && (
+                    <ErrorMessage size={'sm'}>Inneholder en eller flere ugyldige verdier</ErrorMessage>
                   )}
                 </Card>
               ),

--- a/apps/dataset-catalog/components/dataset-form/components/information-model-section.tsx
+++ b/apps/dataset-catalog/components/dataset-form/components/information-model-section.tsx
@@ -18,7 +18,7 @@ interface Props {
 }
 
 export const InformationModelSection = ({ searchEnv }: Props) => {
-  const { setFieldValue, values } = useFormikContext<Dataset>();
+  const { setFieldValue, errors, values } = useFormikContext<Dataset>();
   const [searchTerm, setSearchTerm] = useState<string>('');
 
   const { data: informationModelSuggestions, isLoading: searching } = useSearchInformationModelsSuggestions(
@@ -104,6 +104,7 @@ export const InformationModelSection = ({ searchEnv }: Props) => {
       <UriWithLabelFieldsetTable
         values={values.informationModel}
         fieldName={'informationModel'}
+        errors={errors.informationModel}
         label={
           <TitleWithHelpTextAndTag helpText={localization.datasetForm.helptext.informationModel}>
             {localization.datasetForm.fieldLabel.informationModel}

--- a/apps/dataset-catalog/components/dataset-form/components/relations-section/references-table.tsx
+++ b/apps/dataset-catalog/components/dataset-form/components/relations-section/references-table.tsx
@@ -7,7 +7,7 @@ import relations from '../../utils/relations.json';
 import { AddButton, DeleteButton, EditButton, TitleWithHelpTextAndTag } from '@catalog-frontend/ui';
 import { useState, useRef, useEffect } from 'react';
 import { referenceSchema } from '../../utils/validation-schema';
-import { compact, isEmpty } from 'lodash';
+import { compact, get, isEmpty } from 'lodash';
 import styles from '../../dataset-form.module.css';
 import cn from 'classnames';
 
@@ -30,7 +30,7 @@ const hasNoFieldValues = (values: Reference) => {
 };
 
 export const ReferenceTable = ({ searchEnv }: Props) => {
-  const { values, setFieldValue } = useFormikContext<Dataset>();
+  const { values, errors, setFieldValue } = useFormikContext<Dataset>();
 
   const getUriList = () => {
     return values.references?.map((reference) => reference?.source?.uri).filter((uri) => uri) ?? [];
@@ -44,46 +44,48 @@ export const ReferenceTable = ({ searchEnv }: Props) => {
         {localization.datasetForm.fieldLabel.references}
       </TitleWithHelpTextAndTag>
       {values?.references && compact(values?.references).length > 0 && (
-        <Table
-          size='sm'
-          className={styles.table}
-        >
-          <Table.Head>
-            <Table.Row>
-              <Table.HeaderCell>{localization.datasetForm.fieldLabel.relationType}</Table.HeaderCell>
-              <Table.HeaderCell>{localization.datasetForm.fieldLabel.dataset}</Table.HeaderCell>
-              <Table.HeaderCell aria-label='Actions' />
-            </Table.Row>
-          </Table.Head>
-          <Table.Body>
-            {values?.references &&
-              values?.references.map((ref: Reference, index) => (
-                <Table.Row key={`references-${index}`}>
-                  <Table.Cell>
-                    {getTranslateText(relations.find((rel) => rel.code === ref?.referenceType?.code)?.label) ??
-                      ref?.referenceType?.code}
-                  </Table.Cell>
-                  <Table.Cell>
-                    {getTranslateText(selectedValues?.find((item) => item.uri === ref?.source?.uri)?.title) ??
-                      ref?.source?.uri}
-                  </Table.Cell>
-                  <Table.Cell>
-                    <div className={styles.set}>
-                      <FieldModal
-                        searchEnv={searchEnv}
-                        template={ref}
-                        type={'edit'}
-                        onSuccess={(updatedItem: Reference) => setFieldValue(`references[${index}]`, updatedItem)}
-                        initialUri={ref?.source?.uri}
-                        initialDatasets={selectedValues ?? []}
-                      />
-                      <DeleteButton onClick={() => setFieldValue(`references[${index}]`, undefined)} />
-                    </div>
-                  </Table.Cell>
-                </Table.Row>
-              ))}
-          </Table.Body>
-        </Table>
+        <div className={get(errors, `references`) ? styles.errorBorder : undefined}>
+          <Table
+            size='sm'
+            className={styles.table}
+          >
+            <Table.Head>
+              <Table.Row>
+                <Table.HeaderCell>{localization.datasetForm.fieldLabel.relationType}</Table.HeaderCell>
+                <Table.HeaderCell>{localization.datasetForm.fieldLabel.dataset}</Table.HeaderCell>
+                <Table.HeaderCell aria-label='Actions' />
+              </Table.Row>
+            </Table.Head>
+            <Table.Body>
+              {values?.references &&
+                values?.references.map((ref: Reference, index) => (
+                  <Table.Row key={`references-${index}`}>
+                    <Table.Cell>
+                      {getTranslateText(relations.find((rel) => rel.code === ref?.referenceType?.code)?.label) ??
+                        ref?.referenceType?.code}
+                    </Table.Cell>
+                    <Table.Cell>
+                      {getTranslateText(selectedValues?.find((item) => item.uri === ref?.source?.uri)?.title) ??
+                        ref?.source?.uri}
+                    </Table.Cell>
+                    <Table.Cell>
+                      <div className={styles.set}>
+                        <FieldModal
+                          searchEnv={searchEnv}
+                          template={ref}
+                          type={'edit'}
+                          onSuccess={(updatedItem: Reference) => setFieldValue(`references[${index}]`, updatedItem)}
+                          initialUri={ref?.source?.uri}
+                          initialDatasets={selectedValues ?? []}
+                        />
+                        <DeleteButton onClick={() => setFieldValue(`references[${index}]`, undefined)} />
+                      </div>
+                    </Table.Cell>
+                  </Table.Row>
+                ))}
+            </Table.Body>
+          </Table>
+        </div>
       )}
 
       <div>
@@ -177,7 +179,10 @@ const FieldModal = ({ template, type, onSuccess, searchEnv, initialUri, initialD
                 </Modal.Header>
 
                 <Modal.Content className={cn(styles.modalContent, styles.fieldContainer)}>
-                  <Fieldset legend={localization.datasetForm.fieldLabel.relationType} size='sm'>
+                  <Fieldset
+                    legend={localization.datasetForm.fieldLabel.relationType}
+                    size='sm'
+                  >
                     <Combobox
                       onValueChange={(value) => setFieldValue(`referenceType.code`, value.toString())}
                       value={values.referenceType?.code ? [values.referenceType?.code] : []}
@@ -200,7 +205,10 @@ const FieldModal = ({ template, type, onSuccess, searchEnv, initialUri, initialD
                     </Combobox>
                   </Fieldset>
 
-                  <Fieldset legend={localization.datasetForm.fieldLabel.dataset} size='sm'>
+                  <Fieldset
+                    legend={localization.datasetForm.fieldLabel.dataset}
+                    size='sm'
+                  >
                     <Combobox
                       onChange={(input: any) => setSearchQuery(input.target.value)}
                       onValueChange={(value) => {

--- a/apps/dataset-catalog/components/dataset-form/components/relations-section/relations-section.tsx
+++ b/apps/dataset-catalog/components/dataset-form/components/relations-section/relations-section.tsx
@@ -12,7 +12,7 @@ type Props = {
 };
 
 export const RelationsSection = ({ searchEnv }: Props) => {
-  const { values } = useFormikContext<Dataset>();
+  const { values, errors } = useFormikContext<Dataset>();
 
   return (
     <Box>
@@ -25,6 +25,7 @@ export const RelationsSection = ({ searchEnv }: Props) => {
         <UriWithLabelFieldsetTable
           values={values.relations}
           fieldName={'relations'}
+          errors={errors.relations}
         />
       </div>
     </Box>

--- a/apps/dataset-catalog/components/dataset-form/components/uri-with-label-field-set-table.tsx
+++ b/apps/dataset-catalog/components/dataset-form/components/uri-with-label-field-set-table.tsx
@@ -18,6 +18,7 @@ import { uriWithLabelSchema } from '../utils/validation-schema';
 interface Props {
   values: UriWithLabel[] | undefined;
   fieldName: string;
+  errors: string | undefined;
   showDivider?: boolean;
   label?: string | ReactNode;
   hideHeadWhenEmpty?: boolean;
@@ -39,6 +40,7 @@ export const UriWithLabelFieldsetTable = ({
   fieldName,
   values,
   label,
+  errors,
   hideHeadWhenEmpty = false,
   showDivider,
 }: Props) => {
@@ -50,7 +52,7 @@ export const UriWithLabelFieldsetTable = ({
       <FieldArray
         name={fieldName}
         render={(arrayHelpers) => (
-          <>
+          <div className={errors ? styles.errorBorder : undefined}>
             <Table
               size='sm'
               className={styles.table}
@@ -92,7 +94,7 @@ export const UriWithLabelFieldsetTable = ({
                 onSuccess={(formValues) => arrayHelpers.push(formValues)}
               />
             </div>
-          </>
+          </div>
         )}
       />
       {showDivider && <FieldsetDivider />}

--- a/apps/dataset-catalog/components/dataset-form/dataset-form.module.css
+++ b/apps/dataset-catalog/components/dataset-form/dataset-form.module.css
@@ -89,3 +89,8 @@
     padding-top: 2.5rem;
   }
 }
+
+.errorBorder {
+  border: 2px solid var(--fds-semantic-border-danger-default);
+  border-radius: var(--fds-border_radius-medium);
+}

--- a/apps/dataset-catalog/components/dataset-form/index.tsx
+++ b/apps/dataset-catalog/components/dataset-form/index.tsx
@@ -244,7 +244,7 @@ export const DatasetForm = ({
           const hasError = (fields: (keyof Dataset)[]) => fields.some((field) => Object.keys(errors).includes(field));
           const handleRestoreDataset = (data: StorageData) => {
             if (data?.id !== datasetId) {
-              if (!(data?.id)) {
+              if (!data?.id) {
                 return window.location.replace(`/catalogs/${catalogId}/datasets/new?restore=1`);
               }
               return window.location.replace(`/catalogs/${catalogId}/datasets/${data.id}/edit?restore=1`);
@@ -268,7 +268,14 @@ export const DatasetForm = ({
                     title={localization.datasetForm.heading.about}
                     subtitle={localization.datasetForm.subtitle.about}
                     required
-                    error={hasError(['title'])}
+                    error={hasError([
+                      'title',
+                      'description',
+                      'issued',
+                      'legalBasisForRestriction',
+                      'legalBasisForProcessing',
+                      'legalBasisForAccess',
+                    ])}
                   >
                     <AboutSection />
                   </FormLayout.Section>
@@ -278,7 +285,7 @@ export const DatasetForm = ({
                     title={localization.datasetForm.heading.theme}
                     subtitle={localization.datasetForm.subtitle.theme}
                     required
-                    error={hasError(['euDataTheme'])}
+                    error={hasError(['euDataTheme', 'losTheme'])}
                   >
                     <ThemeSection
                       losThemes={losThemes}
@@ -290,6 +297,7 @@ export const DatasetForm = ({
                     id='distribution-section'
                     title={localization.datasetForm.heading.distributions}
                     subtitle={localization.datasetForm.subtitle.distributions}
+                    error={hasError(['distribution', 'sample'])}
                   >
                     <DistributionSection
                       referenceDataEnv={referenceDataEnv}
@@ -302,7 +310,7 @@ export const DatasetForm = ({
                     id='details-section'
                     title={localization.datasetForm.heading.details}
                     subtitle={localization.datasetForm.subtitle.details}
-                    error={hasError(['landingPage'])}
+                    error={hasError(['landingPage', 'conformsTo'])}
                   >
                     <DetailsSection
                       referenceDataEnv={referenceDataEnv}
@@ -314,6 +322,7 @@ export const DatasetForm = ({
                     id='relation-section'
                     title={localization.datasetForm.heading.relations}
                     subtitle={localization.datasetForm.subtitle.relations}
+                    error={hasError(['references', 'relations'])}
                   >
                     <RelationsSection searchEnv={searchEnv} />
                   </FormLayout.Section>
@@ -322,6 +331,7 @@ export const DatasetForm = ({
                     id='concept-section'
                     title={localization.datasetForm.heading.concept}
                     subtitle={localization.datasetForm.subtitle.concept}
+                    error={hasError(['conceptList', 'keywordList'])}
                   >
                     <ConceptSection searchEnv={searchEnv} />
                   </FormLayout.Section>
@@ -330,6 +340,7 @@ export const DatasetForm = ({
                     id='information-model-section'
                     title={localization.datasetForm.heading.informationModel}
                     subtitle={localization.datasetForm.subtitle.informationModel}
+                    error={hasError(['informationModelsFromFDK', 'informationModel'])}
                   >
                     <InformationModelSection searchEnv={searchEnv} />
                   </FormLayout.Section>

--- a/apps/dataset-catalog/components/dataset-form/utils/validation-schema.tsx
+++ b/apps/dataset-catalog/components/dataset-form/utils/validation-schema.tsx
@@ -58,127 +58,6 @@ const contactPointConfirmValidationSchema = Yup.array()
     return !!(firstContactPoint.email || firstContactPoint.hasTelephone || firstContactPoint.hasURL);
   });
 
-export const draftDatasetSchema = Yup.object().shape({
-  title: Yup.object()
-    .shape({
-      nb: Yup.string()
-        .min(3, localization.datasetForm.validation.title)
-        .label(`${localization.datasetForm.fieldLabel.title} (${localization.language.nb})`)
-        .notRequired(),
-      nn: Yup.string()
-        .min(3, localization.datasetForm.validation.title)
-        .label(`${localization.datasetForm.fieldLabel.title} (${localization.language.nn})`)
-        .notRequired(),
-      en: Yup.string()
-        .min(3, localization.datasetForm.validation.title)
-        .label(`${localization.datasetForm.fieldLabel.title} (${localization.language.en})`)
-        .notRequired(),
-    })
-    .test('title-test', localization.validation.oneLanguageRequired, (title) => {
-      if (!title) {
-        return false;
-      }
-      return !!(title.nb || title.nn || title.en);
-    }),
-
-  landingPage: Yup.array().of(
-    Yup.string()
-      .nullable()
-      .matches(httpsRegex, localization.validation.invalidProtocol)
-      .url(localization.validation.invalidUrl),
-  ),
-
-  legalBasisForRestriction: Yup.array().of(
-    Yup.object().shape({
-      uri: Yup.string()
-        .matches(httpsRegex, localization.validation.invalidProtocol)
-        .url(localization.validation.invalidUrl),
-    }),
-  ),
-
-  legalBasisForProcessing: Yup.array().of(
-    Yup.object().shape({
-      uri: Yup.string()
-        .matches(httpsRegex, localization.validation.invalidProtocol)
-        .url(localization.validation.invalidUrl),
-    }),
-  ),
-
-  legalBasisForAccess: Yup.array().of(
-    Yup.object().shape({
-      uri: Yup.string()
-        .matches(httpsRegex, localization.validation.invalidProtocol)
-        .url(localization.validation.invalidUrl),
-    }),
-  ),
-
-  conformsTo: Yup.array().of(uriWithLabelSchema),
-  informationModel: Yup.array().of(
-    Yup.object().shape({
-      uri: Yup.string()
-        .matches(httpsRegex, localization.validation.invalidProtocol)
-        .url(localization.validation.invalidUrl),
-    }),
-  ),
-  relations: Yup.array().of(
-    Yup.object().shape({
-      uri: Yup.string()
-        .matches(httpsRegex, localization.validation.invalidProtocol)
-        .url(localization.validation.invalidUrl),
-    }),
-  ),
-  contactPoint: contactPointDraftValidationSchema,
-});
-
-export const confirmedDatasetSchema = draftDatasetSchema.shape({
-  title: Yup.object()
-    .shape({
-      nb: Yup.string()
-        .min(3, localization.datasetForm.validation.title)
-        .label(`${localization.datasetForm.fieldLabel.title} (${localization.language.nb})`)
-        .notRequired(),
-      nn: Yup.string()
-        .min(3, localization.datasetForm.validation.title)
-        .label(`${localization.datasetForm.fieldLabel.title} (${localization.language.nn})`)
-        .notRequired(),
-      en: Yup.string()
-        .min(3, localization.datasetForm.validation.title)
-        .label(`${localization.datasetForm.fieldLabel.title} (${localization.language.en})`)
-        .notRequired(),
-    })
-    .test('title-test', localization.validation.oneLanguageRequired, (title) => {
-      if (!title) {
-        return false;
-      }
-      return !!(title.nb || title.nn || title.en);
-    }),
-  description: Yup.object()
-    .shape({
-      nb: Yup.string()
-        .label(`${localization.datasetForm.fieldLabel.description} (${localization.language.nb})`)
-        .min(5, localization.datasetForm.validation.description)
-        .notRequired(),
-      nn: Yup.string()
-        .label(`${localization.datasetForm.fieldLabel.description} (${localization.language.nn})`)
-        .min(5, localization.datasetForm.validation.description)
-        .notRequired(),
-      en: Yup.string()
-        .label(`${localization.datasetForm.fieldLabel.description} (${localization.language.en})`)
-        .min(5, localization.datasetForm.validation.description)
-        .notRequired(),
-    })
-    .test('title-test', localization.validation.oneLanguageRequired, (title) => {
-      if (!title) {
-        return false;
-      }
-      return !!(title.nb || title.nn || title.en);
-    }),
-  euDataTheme: Yup.array()
-    .min(1, localization.datasetForm.validation.euDataTheme)
-    .required(localization.datasetForm.validation.euDataTheme),
-  contactPoint: contactPointConfirmValidationSchema,
-});
-
 export const distributionSectionSchema = Yup.object().shape({
   accessURL: Yup.array()
     .of(
@@ -239,7 +118,7 @@ export const dateSchema = Yup.object().shape({
     .nullable()
     .test({
       test(value) {
-        if (!value) {
+        if (!value && this.parent.startDate) {
           return true;
         }
 
@@ -260,4 +139,96 @@ export const dateSchema = Yup.object().shape({
         });
       },
     }),
+});
+
+export const draftDatasetSchema = Yup.object().shape({
+  title: Yup.object()
+    .shape({
+      nb: Yup.string()
+        .min(3, localization.datasetForm.validation.title)
+        .label(`${localization.datasetForm.fieldLabel.title} (${localization.language.nb})`)
+        .notRequired(),
+      nn: Yup.string()
+        .min(3, localization.datasetForm.validation.title)
+        .label(`${localization.datasetForm.fieldLabel.title} (${localization.language.nn})`)
+        .notRequired(),
+      en: Yup.string()
+        .min(3, localization.datasetForm.validation.title)
+        .label(`${localization.datasetForm.fieldLabel.title} (${localization.language.en})`)
+        .notRequired(),
+    })
+    .test('title-test', localization.validation.oneLanguageRequired, (title) => {
+      if (!title) {
+        return false;
+      }
+      return !!(title.nb || title.nn || title.en);
+    }),
+  contactPoint: contactPointDraftValidationSchema,
+});
+
+export const confirmedDatasetSchema = draftDatasetSchema.shape({
+  title: Yup.object()
+    .shape({
+      nb: Yup.string()
+        .min(3, localization.datasetForm.validation.title)
+        .label(`${localization.datasetForm.fieldLabel.title} (${localization.language.nb})`)
+        .notRequired(),
+      nn: Yup.string()
+        .min(3, localization.datasetForm.validation.title)
+        .label(`${localization.datasetForm.fieldLabel.title} (${localization.language.nn})`)
+        .notRequired(),
+      en: Yup.string()
+        .min(3, localization.datasetForm.validation.title)
+        .label(`${localization.datasetForm.fieldLabel.title} (${localization.language.en})`)
+        .notRequired(),
+    })
+    .test('title-test', localization.validation.oneLanguageRequired, (title) => {
+      if (!title) {
+        return false;
+      }
+      return !!(title.nb || title.nn || title.en);
+    }),
+  description: Yup.object()
+    .shape({
+      nb: Yup.string()
+        .label(`${localization.datasetForm.fieldLabel.description} (${localization.language.nb})`)
+        .min(5, localization.datasetForm.validation.description)
+        .notRequired(),
+      nn: Yup.string()
+        .label(`${localization.datasetForm.fieldLabel.description} (${localization.language.nn})`)
+        .min(5, localization.datasetForm.validation.description)
+        .notRequired(),
+      en: Yup.string()
+        .label(`${localization.datasetForm.fieldLabel.description} (${localization.language.en})`)
+        .min(5, localization.datasetForm.validation.description)
+        .notRequired(),
+    })
+    .test('description-test', localization.validation.oneLanguageRequired, (description) => {
+      if (!description) {
+        return false;
+      }
+      return !!(description.nb || description.nn || description.en);
+    }),
+  temporal: Yup.array().of(dateSchema),
+  euDataTheme: Yup.array()
+    .min(1, localization.datasetForm.validation.euDataTheme)
+    .required(localization.datasetForm.validation.euDataTheme),
+  distribution: Yup.array().of(distributionSectionSchema),
+  sample: Yup.array().of(distributionSectionSchema),
+  landingPage: Yup.array()
+    .nullable()
+    .of(
+      Yup.string()
+        .nonNullable(localization.validation.deleteFieldIfEmpty)
+        .matches(httpsRegex, localization.validation.invalidProtocol)
+        .url(localization.validation.invalidUrl),
+    ),
+  legalBasisForRestriction: Yup.array().of(uriWithLabelSchema),
+  legalBasisForProcessing: Yup.array().of(uriWithLabelSchema),
+  legalBasisForAccess: Yup.array().of(uriWithLabelSchema),
+  conformsTo: Yup.array().of(uriWithLabelSchema),
+  informationModel: Yup.array().of(uriWithLabelSchema),
+  references: Yup.array().of(referenceSchema),
+  relations: Yup.array().of(uriWithLabelSchema),
+  contactPoint: contactPointConfirmValidationSchema,
 });

--- a/libs/ui/src/lib/formik-optional-fields-fieldset/index.tsx
+++ b/libs/ui/src/lib/formik-optional-fields-fieldset/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Fieldset, Box, Card } from '@digdir/designsystemet-react';
+import { Fieldset, Box, Card, ErrorMessage } from '@digdir/designsystemet-react';
 import { useFormikContext } from 'formik';
 
 import styles from './formik-optional-fields-fieldset.module.scss';
@@ -13,9 +13,10 @@ import { FastFieldWithRef } from '../formik-fast-field-with-ref';
 type OptionalFieldsFieldsetProps = {
   legend?: ReactNode;
   availableFields: { valuePath: string; label: string; legend?: ReactNode }[];
+  errorPath?: string;
 };
 
-export const FormikOptionalFieldsFieldset = ({ legend, availableFields }: OptionalFieldsFieldsetProps) => {
+export const FormikOptionalFieldsFieldset = ({ legend, availableFields, errorPath }: OptionalFieldsFieldsetProps) => {
   const { errors, getFieldMeta, setFieldValue } = useFormikContext<Record<string, LocalizedStrings>>();
   const [focus, setFocus] = useState<string | null>();
   const fieldRefs = availableFields.reduce(
@@ -23,7 +24,7 @@ export const FormikOptionalFieldsFieldset = ({ legend, availableFields }: Option
       map[field.valuePath] = React.createRef<HTMLInputElement | HTMLTextAreaElement>();
       return map;
     },
-    {} as Record<string, React.RefObject<HTMLInputElement | HTMLTextAreaElement>>,
+    {} as Record<string, React.RefObject<HTMLInputElement | HTMLTextAreaElement | null>>,
   );
 
   const handleAddField = (fieldName: string) => {
@@ -39,6 +40,8 @@ export const FormikOptionalFieldsFieldset = ({ legend, availableFields }: Option
     const metadata = getFieldMeta(field.valuePath);
     return metadata.value !== undefined;
   });
+
+  const mainError = errorPath ? get(errors, errorPath) : undefined;
 
   const visibleFieldButtons = availableFields.filter((field) => !visibleFields.includes(field));
 
@@ -86,6 +89,7 @@ export const FormikOptionalFieldsFieldset = ({ legend, availableFields }: Option
               </AddButton>
             ))}
           </div>
+          {typeof mainError === 'string' && <ErrorMessage size={'sm'}>{mainError}</ErrorMessage>}
         </Card.Content>
       </Card>
     </Fieldset>

--- a/libs/utils/src/lib/language/nb.ts
+++ b/libs/utils/src/lib/language/nb.ts
@@ -411,7 +411,8 @@ rettigheter, eller at det har oppstått en feil ved henting av tilganger. Vennli
 
   dataset: {
     deleteDataset: 'Slett datasettbeskrivelse',
-    confirmDelete: 'Du er i ferd med å slette datasettbeskrivelsen **{0}**. All data knyttet til datasettbeskrivelsen vil bli permanent slettet, og slettingen kan ikke angres. Er du sikker på at du vil fortsette?',
+    confirmDelete:
+      'Du er i ferd med å slette datasettbeskrivelsen **{0}**. All data knyttet til datasettbeskrivelsen vil bli permanent slettet, og slettingen kan ikke angres. Er du sikker på at du vil fortsette?',
   },
 
   validity: {
@@ -508,6 +509,7 @@ rettigheter, eller at det har oppstått en feil ved henting av tilganger. Vennli
     invalidUrl: `Ugyldig lenke. Vennligst sørg for at lenken har en gyldig adresse, og ender med et toppdomene (f.eks. ‘.no’).`,
     invalidProtocol: `Ugyldig lenke. Vennligst sørg for at lenken starter med ‘https://’.`,
     invalidPhone: 'Ugyldig telefonnummer.',
+    multipleInvalidValues: 'Inneholder en eller flere ugyldige verdier',
     nameRequired: 'Må ha navn',
     accessURLRequired: 'Tilgangslenke må fylles ut.',
     endpointURLRequired: 'Endepunkt må fylles ut.',


### PR DESCRIPTION
Det er nå bedre rapportering i venstremenyen hvor det er feil:
<img width="312" alt="Screenshot 2025-07-10 at 07 27 24" src="https://github.com/user-attachments/assets/66311c16-6298-4461-a346-5650079fe150" />

Distribusjon og kontaktpunkt viser nå litt tekst om de inneholder feil:
<img width="356" alt="Screenshot 2025-07-10 at 07 27 59" src="https://github.com/user-attachments/assets/d27ec116-fca8-488c-9454-8a3349e1b6c6" />

<img width="394" alt="Screenshot 2025-07-10 at 07 28 51" src="https://github.com/user-attachments/assets/d7409e26-e4a5-4068-8f08-8b98f6a5e1e6" />

Tabeller hvor verdier legges til via modal har en rød border om en av verdiene inneholder feil:
<img width="285" alt="Screenshot 2025-07-10 at 07 28 38" src="https://github.com/user-attachments/assets/17302775-8e65-468a-8d02-abfd65206c1f" />

<img width="362" alt="Screenshot 2025-07-10 at 07 28 18" src="https://github.com/user-attachments/assets/833052b4-5045-48ff-b58a-0360e6cec0a2" />

<img width="310" alt="Screenshot 2025-07-10 at 07 27 41" src="https://github.com/user-attachments/assets/e24453c6-ae7f-42e9-a304-7f33dcb8d552" />
