### PR TITLE
fix: override next-auth pages with custom signin

### DIFF
--- a/libs/utils/src/lib/auth/auth-options/index.ts
+++ b/libs/utils/src/lib/auth/auth-options/index.ts
@@ -67,6 +67,13 @@ export const authOptions: AuthOptions = {
       },
     }),
   ],
+  pages: {
+    signIn: '/auth/signin',
+    signOut: '/auth/signout',
+    error: '/auth/signin',
+    verifyRequest: '/auth/signin',
+    newUser: '/auth/signin',
+  },
   callbacks: {
     async session({ session, token }: any) {
       session.user = {


### PR DESCRIPTION
resolve #1315 

Alle innebygde sidene i next-auth overstyres nå med vår custom signin, utenom utlogging som er vår custom signout. Tror error-page var hovedsynderen, men kan også være at noen av de andre også ble rutet til. Jeg kan ikke se noen grunn til hvorfor vi vil gjøre noe annet enn å bare sende de til innlogging via keycloak.