### PR TITLE
fix: update pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-yarn run affected:lint
+yarn lint-staged --relative

--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,0 +1,3 @@
+{
+  "*": ["nx affected:lint --fix --files", "nx format:write --files"]
+}

--- a/package.json
+++ b/package.json
@@ -29,12 +29,9 @@
     "workspace-generator": "nx workspace-generator",
     "dep-graph": "nx dep-graph",
     "help": "nx help",
-    "prepare": "husky install",
+    "prepare": "husky",
     "postinstall": "husky install",
     "graphql:codegen": "graphql-codegen --config codegen.ts"
-  },
-  "lint-staged": {
-    "**/*": "prettier --write --ignore-unknown"
   },
   "private": true,
   "dependencies": {


### PR DESCRIPTION
Feil: `prettier --write` ble aldri kjørt fordi `lint-staged` ikke var i bruk.

Ny `lint-staged` har fått egen fil og kaller `nx format:write` (prettier) i tillegg til `affected:lint` som også vil forsøke å fikse og re-stage filene dine (`--fix`).

Bruk `--no-verify` for å ikke kjøre hooks (ulovlig):
`git commit -m "Your message" --no-verify`