### PR TITLE
fix: Improve date formatting in data service details page

### DIFF
--- a/apps/data-service-catalog/components/details-page-columns/details-page-right-column.tsx
+++ b/apps/data-service-catalog/components/details-page-columns/details-page-right-column.tsx
@@ -5,6 +5,7 @@ import {
   accessRights,
   getTranslateText,
   localization,
+  formatISO,
 } from "@catalog-frontend/utils";
 import { isEmpty } from "lodash";
 import { EnvelopeClosedIcon, LinkIcon, PhoneIcon } from "@navikt/aksel-icons";


### PR DESCRIPTION
## Summary of fixes #1524
- Use `formatISO` with full date options instead of `toLocaleDateString` for the modified date display.

