### PR TITLE
fix: remove empty language fields from data-service form after save

### DIFF
--- a/apps/data-service-catalog/components/data-service-form/utils/data-service-initial-values.tsx
+++ b/apps/data-service-catalog/components/data-service-form/utils/data-service-initial-values.tsx
@@ -1,15 +1,15 @@
 import { DataService, DataServiceToBeCreated } from "@catalog-frontend/types";
-import { removeEmptyOrNullValues } from "@catalog-frontend/utils";
+import { omitBy, isEmpty } from "lodash";
 
 export const dataServiceTemplate = (dataService: DataService): DataService => {
   return {
     ...dataService,
-    title: removeEmptyOrNullValues(dataService?.title),
-    description: removeEmptyOrNullValues(dataService?.description),
-    keywords: removeEmptyOrNullValues(dataService?.keywords),
+    title: omitBy(dataService?.title, isEmpty),
+    description: omitBy(dataService?.description, isEmpty),
+    keywords: omitBy(dataService?.keywords, isEmpty),
     contactPoint: {
       ...dataService?.contactPoint,
-      name: removeEmptyOrNullValues(dataService?.contactPoint?.name),
+      name: omitBy(dataService?.contactPoint?.name, isEmpty),
       email: dataService?.contactPoint?.email || undefined,
       phone: dataService?.contactPoint?.phone || undefined,
       url: dataService?.contactPoint?.url || undefined,

--- a/libs/utils/src/lib/object-manipulation/index.ts
+++ b/libs/utils/src/lib/object-manipulation/index.ts
@@ -1,43 +1,5 @@
 import _ from "lodash";
 
-/**
- * Checks if a value is considered empty (null, undefined, empty string, or empty array).
- */
-const isEmptyValue = (value: unknown): boolean => {
-  if (value === undefined || value === null || value === "") return true;
-  if (Array.isArray(value) && value.length === 0) return true;
-  return false;
-};
-
-/**
- * Recursively removes keys with empty values from an object.
- * Handles empty strings, null, undefined, and empty arrays.
- * E.g., { title: { nb: "", nn: "text" } } becomes { title: { nn: "text" } }
- */
-export const removeEmptyOrNullValues = <T>(obj: T): T => {
-  if (Array.isArray(obj)) {
-    return obj.map((value: unknown) =>
-      typeof value === "object" && value !== null
-        ? removeEmptyOrNullValues(value)
-        : isEmptyValue(value)
-          ? undefined
-          : value,
-    ) as T;
-  }
-
-  if (typeof obj === "object" && obj !== null) {
-    return _.mapValues(
-      _.omitBy(obj as Record<string, unknown>, isEmptyValue),
-      (value: unknown) =>
-        typeof value === "object" && value !== null
-          ? removeEmptyOrNullValues(value)
-          : value,
-    ) as T;
-  }
-
-  return obj;
-};
-
 export const removeEmptyValues = (obj: any): any => {
   if (Array.isArray(obj)) {
     return obj.map((value) =>


### PR DESCRIPTION
# Summary fixes #1538
Fix empty language fields appearing in data-service form after save.

## Changes
- Add dataServiceTemplate function to sanitize form values using lodash's omitBy and isEmpty
- Clean title, description, keywords, and contactPoint.name fields on load, save, and restore