### PR TITLE
feat: Add cancel confirmation modal to the data-service registration page

### DIFF
--- a/apps/data-service-catalog/components/data-service-form/data-service-form.module.css
+++ b/apps/data-service-catalog/components/data-service-form/data-service-form.module.css
@@ -95,20 +95,3 @@
   height: 24px;
   margin: 0 var(--fds-spacing-2);
 }
-
-.stickyFooterBar {
-  position: sticky;
-  bottom: 0px;
-  background-color: #fff;
-  border-top: 1px solid rgb(230, 230, 230);
-  box-shadow: #969ba0 0px 0px 10px -5px;
-  z-index: 10;
-}
-
-.stickyFooterContent {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 1rem;
-  padding: 0.5rem 1rem;
-}

--- a/apps/data-service-catalog/components/data-service-form/index.tsx
+++ b/apps/data-service-catalog/components/data-service-form/index.tsx
@@ -21,6 +21,7 @@ import {
   Snackbar,
   NotificationCarousel,
   SnackbarSeverity,
+  StickyFooterBar,
 } from "@catalog-frontend/ui";
 import { Formik, Form } from "formik";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
@@ -495,80 +496,68 @@ const DataServiceForm = ({
                 </Snackbar>
               )}
 
-              <div className={styles.stickyFooterBar}>
-                <div
-                  className={classNames(
-                    "container",
-                    styles.stickyFooterContent,
-                  )}
-                >
-                  <div>
-                    <div className={classNames(styles.flex, styles.gap2)}>
-                      <Button
-                        size="sm"
-                        type="button"
-                        disabled={
-                          readOnly ||
-                          isSubmitting ||
-                          isValidating ||
-                          isCanceled ||
-                          !dirty
-                        }
-                        onClick={() => {
-                          setValidateOnChange(true);
-                          submitForm();
-                        }}
-                        data-testid="save-data-service-button"
-                      >
-                        {isSubmitting ? (
-                          <Spinner title="Lagrer" size="sm" />
-                        ) : (
-                          "Lagre"
-                        )}
-                      </Button>
-                      <Button
-                        size="sm"
-                        disabled={
-                          readOnly || isSubmitting || isValidating || isCanceled
-                        }
-                        onClick={handleCancel(dirty)}
-                        variant="secondary"
-                        data-testid="cancel-data-service-button"
-                      >
-                        Avbryt
-                      </Button>
-                      <div className={styles.verticalLine}></div>
-                      <div
-                        className={classNames(
-                          styles.flex,
-                          styles.gap2,
-                          styles.noWrap,
-                        )}
-                      >
-                        <Checkbox
-                          size="sm"
-                          value="ignoreRequired"
-                          checked={ignoreRequired}
-                          onChange={(e) => setIgnoreRequired(e.target.checked)}
-                        >
-                          {
-                            localization.dataServiceForm.fieldLabel
-                              .ignoreRequired
-                          }
-                        </Checkbox>
-                        <HelpMarkdown
-                          aria-label={`Help ${localization.dataServiceForm.fieldLabel.ignoreRequired}`}
-                        >
-                          {localization.dataServiceForm.alert.ignoreRequired}
-                        </HelpMarkdown>
-                      </div>
-                    </div>
+              <StickyFooterBar>
+                <div className={styles.footerContent}>
+                  <Button
+                    size="sm"
+                    type="button"
+                    disabled={
+                      readOnly ||
+                      isSubmitting ||
+                      isValidating ||
+                      isCanceled ||
+                      !dirty
+                    }
+                    onClick={() => {
+                      setValidateOnChange(true);
+                      submitForm();
+                    }}
+                    data-testid="save-data-service-button"
+                  >
+                    {isSubmitting ? (
+                      <Spinner title="Lagrer" size="sm" />
+                    ) : (
+                      "Lagre"
+                    )}
+                  </Button>
+                  <Button
+                    size="sm"
+                    disabled={
+                      readOnly || isSubmitting || isValidating || isCanceled
+                    }
+                    onClick={handleCancel(dirty)}
+                    variant="secondary"
+                    data-testid="cancel-data-service-button"
+                  >
+                    Avbryt
+                  </Button>
+                  <div className={styles.verticalLine}></div>
+                  <div
+                    className={classNames(
+                      styles.flex,
+                      styles.gap2,
+                      styles.noWrap,
+                    )}
+                  >
+                    <Checkbox
+                      size="sm"
+                      value="ignoreRequired"
+                      checked={ignoreRequired}
+                      onChange={(e) => setIgnoreRequired(e.target.checked)}
+                    >
+                      {localization.dataServiceForm.fieldLabel.ignoreRequired}
+                    </Checkbox>
+                    <HelpMarkdown
+                      aria-label={`Help ${localization.dataServiceForm.fieldLabel.ignoreRequired}`}
+                    >
+                      {localization.dataServiceForm.alert.ignoreRequired}
+                    </HelpMarkdown>
                   </div>
-                  {notifications.length > 0 && (
-                    <NotificationCarousel notifications={notifications} />
-                  )}
                 </div>
-              </div>
+                {notifications.length > 0 && (
+                  <NotificationCarousel notifications={notifications} />
+                )}
+              </StickyFooterBar>
             </>
           );
         }}


### PR DESCRIPTION
# Summary fixes #1543
  - Add cancel confirmation modal to data service form (only shows when form has unsaved changes)
  - Replace custom sticky footer with shared `StickyFooterBar` UI component