### PR TITLE
refactor: extract form notifications to shared utility

### DIFF
--- a/apps/concept-catalog/components/concept-form/index.tsx
+++ b/apps/concept-catalog/components/concept-form/index.tsx
@@ -4,12 +4,7 @@ import { ReactNode, useEffect, useRef, useState } from "react";
 import classNames from "classnames";
 import { Formik, Form, FormikProps } from "formik";
 import { useSearchParams } from "next/navigation";
-import {
-  Alert,
-  Checkbox,
-  Paragraph,
-  Spinner,
-} from "@digdir/designsystemet-react";
+import { Checkbox, Paragraph, Spinner } from "@digdir/designsystemet-react";
 import {
   DataStorage,
   formatISO,
@@ -30,11 +25,12 @@ import type {
 } from "@catalog-frontend/types";
 import {
   Button,
+  ConfirmModal,
   FormLayout,
   FormikAutoSaver,
-  NotificationCarousel,
+  getFormNotifications,
   HelpMarkdown,
-  ConfirmModal,
+  NotificationCarousel,
   Snackbar,
   SnackbarSeverity,
 } from "@catalog-frontend/ui";
@@ -78,33 +74,6 @@ type Props = {
   showSnackbarSuccessOnInit?: boolean;
   usersResult: UsersResult;
 };
-
-const getNotifications = ({ isValid, hasUnsavedChanges }) => [
-  ...(isValid
-    ? []
-    : [
-        <Alert
-          key={1}
-          size="sm"
-          severity="danger"
-          style={{ background: "none", border: "none", padding: 0 }}
-        >
-          {localization.validation.formError}
-        </Alert>,
-      ]),
-  ...(hasUnsavedChanges
-    ? [
-        <Alert
-          key={1}
-          size="sm"
-          severity="warning"
-          style={{ background: "none", border: "none", padding: 0 }}
-        >
-          {localization.validation.unsavedChanges}
-        </Alert>,
-      ]
-    : []),
-];
 
 const ConceptForm = ({
   afterSubmit,
@@ -362,7 +331,7 @@ const ConceptForm = ({
           setValues,
           setFieldValue,
         }) => {
-          const notifications = getNotifications({
+          const notifications = getFormNotifications({
             isValid,
             hasUnsavedChanges: false,
           });

--- a/apps/data-service-catalog/components/data-service-form/index.tsx
+++ b/apps/data-service-catalog/components/data-service-form/index.tsx
@@ -17,6 +17,7 @@ import {
   ConfirmModal,
   FormLayout,
   FormikAutoSaver,
+  getFormNotifications,
   HelpMarkdown,
   Snackbar,
   NotificationCarousel,
@@ -28,7 +29,6 @@ import { useParams, useRouter, useSearchParams } from "next/navigation";
 import {
   Button,
   Spinner,
-  Alert,
   Paragraph,
   Checkbox,
 } from "@digdir/designsystemet-react";
@@ -65,33 +65,6 @@ type Props = {
   showSnackbarSuccessOnInit?: boolean;
   markDirty?: boolean;
 };
-
-const getNotifications = ({ isValid, hasUnsavedChanges }) => [
-  ...(isValid
-    ? []
-    : [
-        <Alert
-          key={1}
-          size="sm"
-          severity="danger"
-          style={{ background: "none", border: "none", padding: 0 }}
-        >
-          {localization.validation.formError}
-        </Alert>,
-      ]),
-  ...(hasUnsavedChanges
-    ? [
-        <Alert
-          key={1}
-          size="sm"
-          severity="warning"
-          style={{ background: "none", border: "none", padding: 0 }}
-        >
-          {localization.validation.unsavedChanges}
-        </Alert>,
-      ]
-    : []),
-];
 
 const DataServiceForm = ({
   initialValues,
@@ -262,7 +235,7 @@ const DataServiceForm = ({
           values,
           initialValues: formInitialValues,
         }) => {
-          const notifications = getNotifications({
+          const notifications = getFormNotifications({
             isValid: Object.keys(errors).length === 0,
             hasUnsavedChanges: false,
           });

--- a/apps/dataset-catalog/components/dataset-form/index.tsx
+++ b/apps/dataset-catalog/components/dataset-form/index.tsx
@@ -7,7 +7,6 @@ import {
   trimObjectWhitespace,
 } from "@catalog-frontend/utils";
 import {
-  Alert,
   Button,
   Checkbox,
   Paragraph,
@@ -26,6 +25,7 @@ import {
   ConfirmModal,
   FormikAutoSaver,
   FormLayout,
+  getFormNotifications,
   HelpMarkdown,
   NotificationCarousel,
   Snackbar,
@@ -220,38 +220,6 @@ export const DatasetForm = ({
     setShowCancelConfirm(false);
   };
 
-  type Notifications = {
-    isValid: boolean;
-    hasUnsavedChanges: boolean;
-  };
-
-  const getNotifications = ({ isValid, hasUnsavedChanges }: Notifications) => [
-    ...(isValid
-      ? []
-      : [
-          <Alert
-            key={1}
-            size="sm"
-            severity="danger"
-            className={styles.notification}
-          >
-            {localization.validation.formError}
-          </Alert>,
-        ]),
-    ...(hasUnsavedChanges
-      ? [
-          <Alert
-            key={1}
-            size="sm"
-            severity="warning"
-            className={styles.notification}
-          >
-            {localization.validation.unsavedChanges}
-          </Alert>,
-        ]
-      : []),
-  ];
-
   useEffect(() => {
     if (formApprovedStatus === true) {
       setIgnoreRequired(false);
@@ -333,7 +301,7 @@ export const DatasetForm = ({
           errors,
           setValues,
         }) => {
-          const notifications = getNotifications({
+          const notifications = getFormNotifications({
             isValid,
             hasUnsavedChanges: false,
           });

--- a/apps/service-catalog/components/service-form/index.tsx
+++ b/apps/service-catalog/components/service-form/index.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import {
-  Alert,
   Box,
   Checkbox,
   Paragraph,
@@ -16,6 +15,7 @@ import {
   FormikLanguageFieldset,
   FormikOptionalFieldsFieldset,
   FormLayout,
+  getFormNotifications,
   HelpMarkdown,
   NotificationCarousel,
   Select,
@@ -175,38 +175,6 @@ export const ServiceForm = (props: ServiceFormProps) => {
     setShowCancelConfirm(false);
   };
 
-  type Notifications = {
-    isValid: boolean;
-    hasUnsavedChanges: boolean;
-  };
-
-  const getNotifications = ({ isValid, hasUnsavedChanges }: Notifications) => [
-    ...(isValid
-      ? []
-      : [
-          <Alert
-            key={1}
-            size="sm"
-            severity="danger"
-            className={styles.notification}
-          >
-            {localization.validation.formError}
-          </Alert>,
-        ]),
-    ...(hasUnsavedChanges
-      ? [
-          <Alert
-            key={1}
-            size="sm"
-            severity="warning"
-            className={styles.notification}
-          >
-            {localization.validation.unsavedChanges}
-          </Alert>,
-        ]
-      : []),
-  ];
-
   useEffect(() => {
     if (showSnackbarSuccessOnInit) {
       showSnackbarMessage({
@@ -282,7 +250,7 @@ export const ServiceForm = (props: ServiceFormProps) => {
           setValues,
           values,
         }) => {
-          const notifications = getNotifications({
+          const notifications = getFormNotifications({
             isValid,
             hasUnsavedChanges: false,
           });

--- a/libs/ui/src/index.ts
+++ b/libs/ui/src/index.ts
@@ -16,6 +16,7 @@ export * from "./lib/footer";
 export * from "./lib/form-container";
 export * from "./lib/form-heading";
 export * from "./lib/form-layout";
+export * from "./lib/form-notifications";
 export * from "./lib/formik-auto-saver";
 export * from "./lib/formik-fast-field-with-ref";
 export * from "./lib/formik-language-fieldset";

--- a/libs/ui/src/lib/form-notifications/form-notifications.module.css
+++ b/libs/ui/src/lib/form-notifications/form-notifications.module.css
@@ -1,0 +1,5 @@
+.notification {
+  background: none;
+  border: none;
+  padding: 0;
+}

--- a/libs/ui/src/lib/form-notifications/index.tsx
+++ b/libs/ui/src/lib/form-notifications/index.tsx
@@ -1,0 +1,39 @@
+import { ReactNode } from "react";
+import { Alert } from "@digdir/designsystemet-react";
+import { localization } from "@catalog-frontend/utils";
+import styles from "./form-notifications.module.css";
+
+export type FormNotificationsProps = {
+  isValid: boolean;
+  hasUnsavedChanges: boolean;
+};
+
+export const getFormNotifications = ({
+  isValid,
+  hasUnsavedChanges,
+}: FormNotificationsProps): ReactNode[] => [
+  ...(!isValid
+    ? [
+        <Alert
+          key="form-error"
+          size="sm"
+          severity="danger"
+          className={styles.notification}
+        >
+          {localization.validation.formError}
+        </Alert>,
+      ]
+    : []),
+  ...(hasUnsavedChanges
+    ? [
+        <Alert
+          key="unsaved-changes"
+          size="sm"
+          severity="warning"
+          className={styles.notification}
+        >
+          {localization.validation.unsavedChanges}
+        </Alert>,
+      ]
+    : []),
+];


### PR DESCRIPTION
# Summary fixes #1547
- Opprett getFormNotifications utility i libs/ui
- Erstatt dupliserte funksjoner i 4 form-komponenter
- Fiks dupliserte React keys