### PR TITLE
fix: set explicit turbopack root

### DIFF
--- a/apps/catalog-admin/next.config.js
+++ b/apps/catalog-admin/next.config.js
@@ -1,9 +1,11 @@
 //@ts-check
+const path = require("path");
 const { withNx } = require("@nx/next/plugins/with-nx");
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   turbopack: {
+    root: path.join(__dirname, "../.."),
     rules: {
       "*.svg": {
         loaders: ["@svgr/webpack"],

--- a/apps/catalog-portal/next.config.js
+++ b/apps/catalog-portal/next.config.js
@@ -1,9 +1,11 @@
 //@ts-check
+const path = require("path");
 const { withNx } = require("@nx/next/plugins/with-nx");
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   turbopack: {
+    root: path.join(__dirname, "../.."),
     rules: {
       "*.svg": {
         loaders: ["@svgr/webpack"],

--- a/apps/concept-catalog/next.config.js
+++ b/apps/concept-catalog/next.config.js
@@ -1,4 +1,5 @@
 //@ts-check
+const path = require("path");
 const { withNx } = require("@nx/next/plugins/with-nx");
 
 /** @type {import('next').NextConfig} */
@@ -9,6 +10,7 @@ const nextConfig = {
     },
   },
   turbopack: {
+    root: path.join(__dirname, "../.."),
     rules: {
       "*.svg": {
         loaders: ["@svgr/webpack"],

--- a/apps/data-service-catalog/next.config.js
+++ b/apps/data-service-catalog/next.config.js
@@ -1,9 +1,11 @@
 //@ts-check
+const path = require("path");
 const { withNx } = require("@nx/next/plugins/with-nx");
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   turbopack: {
+    root: path.join(__dirname, "../.."),
     rules: {
       "*.svg": {
         loaders: ["@svgr/webpack"],

--- a/apps/dataset-catalog/next.config.js
+++ b/apps/dataset-catalog/next.config.js
@@ -1,4 +1,5 @@
 //@ts-check
+const path = require("path");
 const { withNx } = require("@nx/next/plugins/with-nx");
 
 /** @type {import('next').NextConfig} */
@@ -7,6 +8,7 @@ const nextConfig = {
     DATASET_CATALOG_BASE_URI: process.env.DATASET_CATALOG_BASE_URI,
   },
   turbopack: {
+    root: path.join(__dirname, "../.."),
     rules: {
       "*.svg": {
         loaders: ["@svgr/webpack"],

--- a/apps/service-catalog/next.config.js
+++ b/apps/service-catalog/next.config.js
@@ -1,4 +1,5 @@
 //@ts-check
+const path = require("path");
 const { withNx } = require("@nx/next/plugins/with-nx");
 
 /** @type {import('next').NextConfig} */
@@ -7,6 +8,7 @@ const nextConfig = {
     SERVICE_CATALOG_BASE_URI: process.env.SERVICE_CATALOG_BASE_URI,
   },
   turbopack: {
+    root: path.join(__dirname, "../.."),
     rules: {
       "*.svg": {
         loaders: ["@svgr/webpack"],


### PR DESCRIPTION
# Summary fixes #1557 
-  Set explicit turbopack.root in all Next.js configs to fix dev server hanging when lockfiles exist in parent directories.