### PR TITLE
fix: validation handles both old and new data service id

### DIFF
--- a/apps/data-service-catalog/app/catalogs/[catalogId]/data-services/[dataServiceId]/edit/page.tsx
+++ b/apps/data-service-catalog/app/catalogs/[catalogId]/data-services/[dataServiceId]/edit/page.tsx
@@ -13,7 +13,7 @@ import {
   getTranslateText,
   localization,
   redirectToSignIn,
-  validUUID,
+  validDataServiceID,
 } from "@catalog-frontend/utils";
 import { redirect, RedirectType } from "next/navigation";
 import { withWriteProtectedPage } from "@data-service-catalog/utils/auth";
@@ -24,7 +24,7 @@ const EditDataServicePage = withWriteProtectedPage(
   ({ catalogId, dataServiceId }) =>
     `/catalogs/${catalogId}/data-services/${dataServiceId}/edit`,
   async ({ catalogId, dataServiceId, session }) => {
-    if (!dataServiceId || !validUUID(dataServiceId)) {
+    if (!dataServiceId || !validDataServiceID(dataServiceId)) {
       return redirect(`/notfound`, RedirectType.replace);
     }
     if (!session) {

--- a/apps/data-service-catalog/app/catalogs/[catalogId]/data-services/[dataServiceId]/page.tsx
+++ b/apps/data-service-catalog/app/catalogs/[catalogId]/data-services/[dataServiceId]/page.tsx
@@ -8,18 +8,16 @@ import {
   hasOrganizationWritePermission,
   localization,
   redirectToSignIn,
-  validUUID,
+  validDataServiceID,
 } from "@catalog-frontend/utils";
 import {
   getCurrencies,
-  getDataServiceById,
   getDistributionStatuses,
   getOpenLicenses,
   getPlannedAvailabilities,
 } from "@catalog-frontend/data-access";
 import { redirect, RedirectType } from "next/navigation";
 import DataServiceDetailsPageClient from "./data-service-details-page-client";
-import { dataServiceValidationSchema } from "../../../../../components/data-service-form/utils/validation-schema";
 import { withReadProtectedPage } from "@data-service-catalog/utils/auth";
 import { fetchDataServiceWithRetry } from "@data-service-catalog/utils/data-service";
 
@@ -27,7 +25,7 @@ const EditDataServicePage = withReadProtectedPage(
   ({ catalogId, dataServiceId }) =>
     `/catalogs/${catalogId}/data-services/${dataServiceId}`,
   async ({ catalogId, dataServiceId, session }) => {
-    if (!dataServiceId || !validUUID(dataServiceId)) {
+    if (!dataServiceId || !validDataServiceID(dataServiceId)) {
       return redirect(`/notfound`, RedirectType.replace);
     }
     if (!session) {

--- a/apps/data-service-catalog/app/catalogs/[catalogId]/data-services/import-results/[resultId]/page.tsx
+++ b/apps/data-service-catalog/app/catalogs/[catalogId]/data-services/import-results/[resultId]/page.tsx
@@ -3,7 +3,7 @@ import {
   BreadcrumbType,
   DesignBanner,
 } from "@catalog-frontend/ui";
-import { localization, validUUID } from "@catalog-frontend/utils";
+import { localization, validDataServiceID } from "@catalog-frontend/utils";
 import { getDataServiceImportResultById } from "@catalog-frontend/data-access";
 import { redirect, RedirectType } from "next/navigation";
 import ImportResultDetailsPageClient from "./import-result-details-page-client";
@@ -13,7 +13,7 @@ const ImportResultDetailsPage = withAdminProtectedPage(
   ({ catalogId, resultId }) =>
     `/catalogs/${catalogId}/data-services/import-results/${resultId}`,
   async ({ catalogId, resultId, session }) => {
-    if (!resultId || !validUUID(resultId)) {
+    if (!resultId || !validDataServiceID(resultId)) {
       return redirect(`/notfound`, RedirectType.replace);
     }
     const importResult = await getDataServiceImportResultById(

--- a/apps/data-service-catalog/proxy.ts
+++ b/apps/data-service-catalog/proxy.ts
@@ -6,9 +6,9 @@ import {
   hasOrganizationWritePermission,
   hasSystemAdminPermission,
   validateOidcUserSession,
-} from "@catalog-frontend/utils/src/lib/auth/token";
-import { validUUID } from "@catalog-frontend/utils/src/lib/validation/uuid";
-import { validOrganizationNumber } from "@catalog-frontend/utils/src/lib/validation/organization-number";
+  validDataServiceID,
+  validOrganizationNumber,
+} from "@catalog-frontend/utils";
 
 export const config = {
   matcher: "/catalogs/:path*",
@@ -21,7 +21,7 @@ export const proxy = withAuth(
     const pathname = req.nextUrl.pathname;
     const parts = pathname.split("/");
     const catalogId = validOrganizationNumber(parts[2]) ? parts[2] : undefined;
-    const dataServiceId = validUUID(parts[4]) ? parts[4] : undefined;
+    const dataServiceId = validDataServiceID(parts[4]) ? parts[4] : undefined;
 
     const writePermissionsRoutes = [
       `/catalogs/${catalogId}/data-services/${dataServiceId}/edit`,
@@ -34,7 +34,7 @@ export const proxy = withAuth(
       );
     }
 
-    if (dataServiceId && !validUUID(dataServiceId)) {
+    if (dataServiceId && !validDataServiceID(dataServiceId)) {
       return NextResponse.rewrite(
         new URL("/not-found", process.env.NEXTAUTH_URL),
       );

--- a/apps/data-service-catalog/utils/auth.ts
+++ b/apps/data-service-catalog/utils/auth.ts
@@ -5,8 +5,8 @@ import {
   hasOrganizationWritePermission,
   hasSystemAdminPermission,
   redirectToSignIn,
+  validDataServiceID,
   validOrganizationNumber,
-  validUUID,
 } from "@catalog-frontend/utils";
 import { RedirectType, redirect } from "next/navigation";
 
@@ -37,7 +37,7 @@ const withProtectedPage = (
     }
 
     [dataServiceId].forEach((param) => {
-      if (params[param] && !validUUID(params[param])) {
+      if (params[param] && !validDataServiceID(params[param])) {
         return redirect(`/not-found`, RedirectType.replace);
       }
     });

--- a/libs/data-access/src/lib/data-service/api/index.ts
+++ b/libs/data-access/src/lib/data-service/api/index.ts
@@ -3,8 +3,8 @@
 import { DataService } from "@catalog-frontend/types";
 import { Operation } from "fast-json-patch";
 import {
+  validateDataServiceID,
   validateOrganizationNumber,
-  validateUUID,
   validateAndEncodeUrlSafe,
 } from "@catalog-frontend/utils";
 
@@ -50,7 +50,7 @@ export const getDataServiceById = async (
   accessToken: string,
 ) => {
   validateOrganizationNumber(catalogId, "getDataServiceById");
-  validateUUID(dataServiceId, "getDataServiceById");
+  validateDataServiceID(dataServiceId, "getDataServiceById");
   const encodedCatalogId = validateAndEncodeUrlSafe(
     catalogId,
     "catalog ID",
@@ -142,7 +142,7 @@ export const deleteDataService = async (
   accessToken: string,
 ) => {
   validateOrganizationNumber(catalogId, "deleteDataService");
-  validateUUID(dataServiceId, "deleteDataService");
+  validateDataServiceID(dataServiceId, "deleteDataService");
   const encodedCatalogId = validateAndEncodeUrlSafe(
     catalogId,
     "catalog ID",
@@ -172,7 +172,7 @@ export const updateDataService = async (
   accessToken: string,
 ) => {
   validateOrganizationNumber(catalogId, "updateDataService");
-  validateUUID(dataServiceId, "updateDataService");
+  validateDataServiceID(dataServiceId, "updateDataService");
   const encodedCatalogId = validateAndEncodeUrlSafe(
     catalogId,
     "catalog ID",
@@ -202,7 +202,7 @@ export const publishDataService = async (
   accessToken: string,
 ) => {
   validateOrganizationNumber(catalogId, "publishDataService");
-  validateUUID(dataServiceId, "publishDataService");
+  validateDataServiceID(dataServiceId, "publishDataService");
   const encodedCatalogId = validateAndEncodeUrlSafe(
     catalogId,
     "catalog ID",
@@ -231,7 +231,7 @@ export const unpublishDataService = async (
   accessToken: string,
 ) => {
   validateOrganizationNumber(catalogId, "unpublishDataService");
-  validateUUID(dataServiceId, "unpublishDataService");
+  validateDataServiceID(dataServiceId, "unpublishDataService");
   const encodedCatalogId = validateAndEncodeUrlSafe(
     catalogId,
     "catalog ID",
@@ -282,7 +282,7 @@ export const getDataServiceImportResultById = async (
   accessToken: string,
 ) => {
   validateOrganizationNumber(catalogId, "getDataServiceImportResultById");
-  validateUUID(resultId, "getDataServiceImportResultById");
+  validateDataServiceID(resultId, "getDataServiceImportResultById");
   const encodedCatalogId = validateAndEncodeUrlSafe(
     catalogId,
     "catalog ID",
@@ -311,7 +311,7 @@ export const deleteImportResult = async (
   accessToken: string,
 ) => {
   validateOrganizationNumber(catalogId, "deleteImportResult");
-  validateUUID(resultId, "deleteImportResult");
+  validateDataServiceID(resultId, "deleteImportResult");
   const encodedCatalogId = validateAndEncodeUrlSafe(
     catalogId,
     "catalog ID",

--- a/libs/utils/src/index.ts
+++ b/libs/utils/src/index.ts
@@ -19,6 +19,7 @@ export * from "./lib/text/date";
 export * from "./lib/text/number-parser";
 export * from "./lib/text/text";
 export * from "./lib/validation/change-requests-id";
+export * from "./lib/validation/data-service-id";
 export * from "./lib/validation/image-upload";
 export * from "./lib/validation/organization-number";
 export * from "./lib/validation/search";

--- a/libs/utils/src/lib/validation/data-service-id.ts
+++ b/libs/utils/src/lib/validation/data-service-id.ts
@@ -1,0 +1,20 @@
+export const validDataServiceID = (id?: string | null) => {
+  return id?.match(/^[0-9a-f-]{20,40}$/i) !== null;
+};
+
+/**
+ * Validates data service ID and throws an error if invalid
+ * @param id - The ID to validate
+ * @param functionName - Name of the function calling this validation (for error message)
+ * @throws Error if data service ID is invalid
+ */
+export const validateDataServiceID = (
+  id: string,
+  functionName: string,
+): void => {
+  if (!validDataServiceID(id)) {
+    throw new Error(
+      `Invalid data service ID '${id}' in ${functionName}. ID must be a valid data service ID format.`,
+    );
+  }
+};


### PR DESCRIPTION
Id fra gammel løsning er ikke på UUID-format, så bruker mindre restriktiv validering for å godta både gamle IDer og nye med UUID-format