### PR TITLE
feat: add version field to data service

### DIFF
--- a/apps/data-service-catalog/components/data-service-form/components/about-section.tsx
+++ b/apps/data-service-catalog/components/data-service-form/components/about-section.tsx
@@ -1,4 +1,5 @@
 import {
+  FastFieldWithRef,
   FieldsetDivider,
   FormikLanguageFieldset,
   TitleWithHelpTextAndTag,
@@ -51,6 +52,21 @@ export const AboutSection = () => {
           </TitleWithHelpTextAndTag>
         }
         multiple
+      />
+
+      <FieldsetDivider />
+
+      <FastFieldWithRef
+        name="version"
+        as={Textfield}
+        size="sm"
+        label={
+          <TitleWithHelpTextAndTag
+            helpText={localization.dataServiceForm.helptext.version}
+          >
+            {localization.dataServiceForm.fieldLabel.version}
+          </TitleWithHelpTextAndTag>
+        }
       />
     </Box>
   );

--- a/apps/data-service-catalog/components/data-service-form/utils/data-service-initial-values.tsx
+++ b/apps/data-service-catalog/components/data-service-form/utils/data-service-initial-values.tsx
@@ -7,6 +7,7 @@ export const dataServiceTemplate = (dataService: DataService): DataService => {
     title: omitBy(dataService?.title, isEmpty),
     description: omitBy(dataService?.description, isEmpty),
     keywords: omitBy(dataService?.keywords, isEmpty),
+    version: dataService?.version ?? "",
     contactPoint: {
       ...dataService?.contactPoint,
       name: omitBy(dataService?.contactPoint?.name, isEmpty),
@@ -28,6 +29,7 @@ export const dataServiceToBeCreatedTemplate = (): DataServiceToBeCreated => {
     accessRights: "none",
     formats: [],
     keywords: {},
+    version: "",
     landingPage: "",
     pages: [],
     license: "none",

--- a/apps/data-service-catalog/components/details-page-columns/details-page-left-column.tsx
+++ b/apps/data-service-catalog/components/details-page-columns/details-page-left-column.tsx
@@ -137,6 +137,15 @@ export const LeftColumn = ({
         </InfoCard.Item>
       )}
 
+      {!isEmpty(dataService?.version) && (
+        <InfoCard.Item
+          title={localization.dataServiceForm.fieldLabel.version}
+          data-testid="data-service-version"
+        >
+          {dataService.version}
+        </InfoCard.Item>
+      )}
+
       {!isEmpty(dataService?.servesDataset) && (
         <InfoCard.Item
           title={localization.dataServiceForm.fieldLabel.servesDataset}

--- a/libs/types/src/lib/data-service.ts
+++ b/libs/types/src/lib/data-service.ts
@@ -18,6 +18,7 @@ export interface DataServiceToBeCreated {
   accessRights?: string;
   formats?: string[];
   keywords: LocalizedStrings;
+  version?: string;
   landingPage?: string;
   pages?: string[];
   license?: string;

--- a/libs/utils/src/lib/language/data.service.form.nb.ts
+++ b/libs/utils/src/lib/language/data.service.form.nb.ts
@@ -25,6 +25,7 @@ export const dataServiceFormNb = {
       "Brukes til å oppgi tjenestens modenhet, velges fra EU’s kontrollerte vokabular _Distribution status_.",
     keywords:
       "Oppgi emneord (eller tag) som beskriver datatjenesten, f.eks. _eksempel_, _datatjeneste_ (bokmål) / _example_, _data service_ (Engelsk).",
+    version: "Versjon av API-et, f.eks. 1.0.0 eller v2.",
     servesDataset:
       "Brukes til å referere til datasett som datatjenesten kan distribuere.",
     availability:
@@ -74,6 +75,7 @@ export const dataServiceFormNb = {
     license: "Lisens",
     status: "Status",
     keywords: "Emneord",
+    version: "Versjon",
     availability: "Tilgjengelighet",
     costs: "Gebyr",
     costDocumentation: "Dokumentasjon",


### PR DESCRIPTION
## Summary fixes #955

- Add version field to data service form in the about section
- Display version on data service details page below keywords
- Add type definition, localization, and initial values for version field

### Detail section:
<img width="976" height="364" alt="Skjermbilde 2026-01-20 135029" src="https://github.com/user-attachments/assets/fff1f34a-167d-418a-a5f8-0d2b2c530221" />

### Skjema:
<img width="765" height="262" alt="Skjermbilde 2026-01-20 135052" src="https://github.com/user-attachments/assets/f1bcea1e-6f62-4a8b-8e85-efae7e3dd953" />
