### PR TITLE
feat: add version field max 50 char validation

### DIFF
--- a/apps/data-service-catalog/components/data-service-form/components/about-section.tsx
+++ b/apps/data-service-catalog/components/data-service-form/components/about-section.tsx
@@ -1,14 +1,17 @@
 import {
-  FastFieldWithRef,
   FieldsetDivider,
   FormikLanguageFieldset,
   TitleWithHelpTextAndTag,
   TextareaWithPrefix,
 } from "@catalog-frontend/ui";
 import { localization } from "@catalog-frontend/utils";
-import { Box, Textfield } from "@digdir/designsystemet-react";
+import { Box, ErrorMessage, Textfield } from "@digdir/designsystemet-react";
+import { DataService } from "@catalog-frontend/types";
+import { FastField, useFormikContext } from "formik";
 
 export const AboutSection = () => {
+  const { errors } = useFormikContext<DataService>();
+
   return (
     <Box>
       <FormikLanguageFieldset
@@ -56,9 +59,9 @@ export const AboutSection = () => {
 
       <FieldsetDivider />
 
-      <FastFieldWithRef
-        name="version"
+      <FastField
         as={Textfield}
+        name="version"
         size="sm"
         label={
           <TitleWithHelpTextAndTag
@@ -67,6 +70,7 @@ export const AboutSection = () => {
             {localization.dataServiceForm.fieldLabel.version}
           </TitleWithHelpTextAndTag>
         }
+        error={errors?.version}
       />
     </Box>
   );

--- a/apps/data-service-catalog/components/data-service-form/index.tsx
+++ b/apps/data-service-catalog/components/data-service-form/index.tsx
@@ -337,7 +337,7 @@ const DataServiceForm = ({
                           ["title", "description"].includes(field),
                         )
                       }
-                      error={hasError(["title"])}
+                      error={hasError(["title", "version"])}
                     >
                       <AboutSection />
                     </FormLayout.Section>

--- a/apps/data-service-catalog/components/data-service-form/utils/validation-schema.tsx
+++ b/apps/data-service-catalog/components/data-service-form/utils/validation-schema.tsx
@@ -16,6 +16,10 @@ export const draftDataServiceValidationSchema = () =>
       nn: Yup.string().notRequired(),
       en: Yup.string().notRequired(),
     }),
+    version: Yup.string().max(
+      50,
+      localization.dataServiceForm.validation.versionMaxLength,
+    ),
     endpointUrl: Yup.string()
       .label(localization.dataServiceForm.fieldLabel.endpoint)
       .notRequired()
@@ -93,6 +97,10 @@ export const dataServiceValidationSchema = () =>
           return !!(title.nb || title.nn || title.en);
         },
       ),
+    version: Yup.string().max(
+      50,
+      localization.dataServiceForm.validation.versionMaxLength,
+    ),
     endpointUrl: Yup.string()
       .label(localization.dataServiceForm.fieldLabel.endpoint)
       .required(localization.validation.endpointURLRequired)

--- a/libs/utils/src/lib/language/data.service.form.nb.ts
+++ b/libs/utils/src/lib/language/data.service.form.nb.ts
@@ -89,6 +89,7 @@ export const dataServiceFormNb = {
   validation: {
     costValueRequiredWhenMissingDoc:
       "Beløp er påkrevd når ingen dokumentasjon er oppgitt.",
+    versionMaxLength: "Versjon kan ikke være lengre enn 50 tegn.",
   },
   alert: {
     confirmDelete: "Er du sikker på at du vil slette API-beskrivelsen?",


### PR DESCRIPTION
## Summary

- Add max 50 character validation for version field in data service form
- Add validation error message in Norwegian localization