### PR TITLE
fix: async get of params in catalog-admin layout

### DIFF
--- a/apps/catalog-admin/app/catalogs/[catalogId]/layout.tsx
+++ b/apps/catalog-admin/app/catalogs/[catalogId]/layout.tsx
@@ -8,13 +8,14 @@ export const metadata: Metadata = {
   description: localization.catalogType.admin,
 };
 
-const PageLayout = ({
-  children,
-  params: { catalogId },
-}: {
+const PageLayout = async (props: {
   children: React.ReactNode;
-  params: { catalogId: string };
+  params: Promise<{ catalogId: string }>;
 }) => {
+  const params = await props.params;
+  const { catalogId } = params;
+  const { children } = props;
+
   return (
     <Layout
       catalogAdminUrl={process.env.CATALOG_ADMIN_BASE_URI}


### PR DESCRIPTION
fixes https://github.com/Informasjonsforvaltning/fdk-issue-tracker/issues/1232

Feilen fra loggen:
````
Error: Route "/catalogs/[catalogId]" used `params.catalogId`. `params` is a Promise and must be unwrapped with `await` or `React.use()` before accessing its properties. Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis
    at PageLayout (app/catalogs/[catalogId]/layout.tsx:13:13)
  11 | const PageLayout = ({
  12 |   children,
> 13 |   params: { catalogId },
     |             ^
  14 | }: {
  15 |   children: React.ReactNode;
  16 |   params: { catalogId: string };
````

Så koden hadde ikke tilgang til catalogId når den skulle sjekke terms, ser ut til å fungere med async-henting av params