### PR TITLE
Chore/1567

### DIFF
--- a/apps/concept-catalog/components/concept-form/components/relation-section.tsx
+++ b/apps/concept-catalog/components/concept-form/components/relation-section.tsx
@@ -121,7 +121,7 @@ export const RelationSection = ({
       filters: {
         originalId: {
           value: relations
-            .filter((rel) => rel.internal)
+            .filter((rel) => rel.internal && rel.relatertBegrep)
             .map((rel) => rel.relatertBegrep as string),
         },
       },


### PR DESCRIPTION
Fixes: https://github.com/Informasjonsforvaltning/catalog-frontend/issues/1567

Problemet var en følgefeil av at useQuery-kallet feilet med 500 og data.hits var undefined.

PR fikser årsaken til 500-feilen (ugyldig input), men samme problem kan fortsatt oppstå, da komponenten ikke tar høyde for at useQuery kan feile.