### PR TITLE
fix: improve auth session validation logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,6 @@ reports
 
 .nx/cache
 .nx/workspace-data
+
+# Agents
+.claude


### PR DESCRIPTION
## Summary

- Check for `RefreshAccessTokenError` flag to prevent modal showing after login
- Add early return when session has error state
- Expand session validation logic with explicit checks
- Add debug logging to trace auth flow issues