### PR TITLE
fix: prioritize new login in jwt callback

### DIFF
--- a/libs/utils/src/lib/auth/auth-options/index.ts
+++ b/libs/utils/src/lib/auth/auth-options/index.ts
@@ -6,6 +6,7 @@ const isAfterNow = (date: number) => {
 };
 
 const refreshToken = async (token: any) => {
+  console.log("[AUTH] refreshToken: called");
   const maxRetries = 3;
   let attempt = 0;
   let lastError;
@@ -30,16 +31,21 @@ const refreshToken = async (token: any) => {
 
       if (!response.ok) throw tokens;
 
+      const newExpiresAt = Math.floor(
+        Date.now() / 1000 + Number(tokens.expires_in),
+      );
+      console.log("[AUTH] refreshToken: success", { newExpiresAt });
+
       return {
         ...token,
         access_token: tokens.access_token,
-        expires_at: Math.floor(Date.now() / 1000 + Number(tokens.expires_in)),
+        expires_at: newExpiresAt,
         refresh_token: tokens.refresh_token ?? token.refresh_token,
       };
     } catch (error) {
       lastError = error;
       console.error(
-        `Failed to refresh access token (attempt ${attempt + 1}):`,
+        `[AUTH] refreshToken: failed (attempt ${attempt + 1}):`,
         error,
       );
       attempt++;
@@ -86,6 +92,7 @@ export const authOptions: AuthOptions = {
   },
   callbacks: {
     async session({ session, token }: any) {
+      console.log("[AUTH] session callback: called");
       session.user = {
         id: token.id ?? null,
         name: token.name,
@@ -99,30 +106,59 @@ export const authOptions: AuthOptions = {
         session.error = token.error;
       }
 
+      console.log("[AUTH] session callback: result", {
+        userId: session.user?.id,
+        hasAccessToken: !!session.accessToken,
+        expiresAt: session.accessTokenExpiresAt,
+        hasError: !!session.error,
+      });
+
       return session;
     },
     async jwt({ token, user, account, trigger }) {
+      const expiresIn = token.expires_at
+        ? Number(token.expires_at) - Math.floor(Date.now() / 1000)
+        : null;
+      console.log("[AUTH] jwt callback: called", {
+        trigger,
+        hasAccount: !!account,
+        hasUser: !!user,
+        expiresAt: token.expires_at,
+        expiresIn,
+      });
+
+      // 1) NEW LOGIN: if we have an account, always store those tokens
+      if (account) {
+        console.log("[AUTH] jwt callback: initial login, saving tokens");
+        return {
+          ...token,
+          ...user,
+          access_token: account.access_token,
+          expires_at:
+            (account as any).expires_at ??
+            Math.floor(Date.now() / 1000 + Number(account.expires_in)),
+          refresh_token: account.refresh_token ?? token.refresh_token,
+          id_token: account.id_token,
+          error: undefined,
+          refreshError: undefined,
+        };
+      }
+
+      // 2) Manual update trigger: refresh
       if (trigger === "update") {
+        console.log("[AUTH] jwt callback: update trigger, refreshing token");
         return refreshToken(token);
       }
 
-      if (account) {
-        // Save the access token and refresh token in the JWT on the initial login
-        return {
-          ...user,
-          access_token: account.access_token,
-          expires_at: Math.floor(
-            Date.now() / 1000 + Number(account.expires_in),
-          ),
-          refresh_token: account.refresh_token,
-          id_token: account.id_token,
-        };
-      } else if (isAfterNow(Number(token.expires_at))) {
-        // If the access token has not expired yet, return it
+      // 3) Token still valid
+      if (token.expires_at && Date.now() < Number(token.expires_at) * 1000) {
+        console.log("[AUTH] jwt callback: token valid, returning as-is");
         return token;
-      } else {
-        return refreshToken(token);
       }
+
+      // 4) Token expired
+      console.log("[AUTH] jwt callback: token expired, refreshing");
+      return refreshToken(token);
     },
   },
 };


### PR DESCRIPTION
## Summary

- Reorder JWT callback logic to prioritize new login (`account`) over update trigger
- Add `...token` spread to preserve internal JWT fields (`sub`, `iat`, etc.) on initial login
- Clear error states (`error`, `refreshError`) when storing new login tokens
- Use `account.expires_at` if provider supplies it, otherwise compute from `expires_in`
- Add comprehensive logging to JWT callback for better debugging
- Fix potential race condition where stale tokens could be refreshed instead of using fresh login tokens