### PR TITLE
replace ASCII characters U+2018, U+2019 -> U+0060

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Monorepo powering the web frontend for all [registration solutions](https://catalog-portal.fellesdatakatalog.digdir.no/). Built with [NX](https://nx.dev/), it includes Next.js web applications (catalogs, portal and admin), reusable React UI components and other related libraries.
 
-For a broader understanding of the system’s context, refer to the [architecture documentation](https://github.com/Informasjonsforvaltning/architecture-documentation) wiki. For more specific
+For a broader understanding of the system's context, refer to the [architecture documentation](https://github.com/Informasjonsforvaltning/architecture-documentation) wiki. For more specific
 context on this application, see the [Registration](https://github.com/Informasjonsforvaltning/architecture-documentation/wiki/Architecture-documentation#registration) subsystem section.
 
 ## Getting started

--- a/libs/utils/src/lib/language/concept.form.nb.ts
+++ b/libs/utils/src/lib/language/concept.form.nb.ts
@@ -254,7 +254,7 @@ Eksempel: Versjon 2.1.3 betyr andre hovedversjon, første mindre oppdatering, og
     minLength: "Verdien må være minst {0} karakterer lang.",
     required: "Feltet må fylles ut.",
     invalidUrl:
-      "Ugyldig lenke. Vennligst sørg for at lenken starter med ‘https://’ og inneholder et gyldig toppdomene (f.eks. ‘.no’).",
+      "Ugyldig lenke. Vennligst sørg for at lenken starter med 'https://' og inneholder et gyldig toppdomene (f.eks. '.no').",
     minOneSource: "Du må ha minst en kilde",
     version: "Versjon må være større en v{min}",
     languageRequired: "{label} ({language}) er påkrevd",

--- a/libs/utils/src/lib/language/data.service.form.nb.ts
+++ b/libs/utils/src/lib/language/data.service.form.nb.ts
@@ -22,14 +22,14 @@ export const dataServiceFormNb = {
     license:
       "Lisensen som API-et er gjort tilgjengelig under. Velges fra EUs kontrollerte vokabular _License_.",
     status:
-      "Brukes til å oppgi tjenestens modenhet, velges fra EU’s kontrollerte vokabular _Distribution status_.",
+      "Brukes til å oppgi tjenestens modenhet, velges fra EU's kontrollerte vokabular _Distribution status_.",
     keywords:
       "Oppgi emneord (eller tag) som beskriver datatjenesten, f.eks. _eksempel_, _datatjeneste_ (bokmål) / _example_, _data service_ (Engelsk).",
     version: "Versjon av API-et, f.eks. 1.0.0 eller v2.",
     servesDataset:
       "Brukes til å referere til datasett som datatjenesten kan distribuere.",
     availability:
-      "Brukes til å angi hvor lenge det er planlagt å holde datatjenesten tilgjengelig, verdien velges fra EU’s kontrollerte vokabular _Planned availability_.",
+      "Brukes til å angi hvor lenge det er planlagt å holde datatjenesten tilgjengelig, verdien velges fra EU's kontrollerte vokabular _Planned availability_.",
     costs:
       "Brukes til å oppgi prisinfomasjonen og utrekningsgrunnlaget for ett eller flere gebyr for bruk av APIet.",
     costDescription: "Brukes til å oppgi en tekstlig beskrivelse av gebyret.",

--- a/libs/utils/src/lib/language/dataset.form.nb.ts
+++ b/libs/utils/src/lib/language/dataset.form.nb.ts
@@ -38,7 +38,7 @@ Datasett som har en distribusjon der det er lagt til en åpen lisens vil bli mar
 Dersom dette er en lenke hvor datasettet lastes ned direkte, og datasettet ikke tilbyr noen annen form for distribusjon: legg inn lenken i dette feltet, legg til feltet 'nedlastingslenke' i tillegg, og fyll inn samme lenke her.`,
     downloadURL: "Direktelenke (URL) til en nedlastbar fil av datasettet.",
     fileType:
-      "Filtypen til distribusjonen. Velges fra EU’s kontrollerte vokabular [file type](https://op.europa.eu/en/web/eu-vocabularies/concept-scheme/-/resource?uri=http://publications.europa.eu/resource/authority/file-type).",
+      "Filtypen til distribusjonen. Velges fra EU's kontrollerte vokabular [file type](https://op.europa.eu/en/web/eu-vocabularies/concept-scheme/-/resource?uri=http://publications.europa.eu/resource/authority/file-type).",
     mediaType:
       "Innholdets spesifikke type. Medietype velges fra listen [IANA Media Types](https://www.iana.org/assignments/media-types/media-types.xhtml).",
     accessServices:
@@ -56,11 +56,11 @@ Dersom man velger en åpen lisens, vil datasettet bli merket med "Åpne data".`,
     lastUpdated: "Dato for siste oppdatering av innholdet i datasettet.",
     landingPage:
       "Lenke til en nettside som gir tilgang til datasettet, dets distribusjoner og/eller tilleggsinformasjon.",
-    type: "Datasettets spesifikke type. Dette kan velges blant EU’s kontrollerte vokabular [dataset type](https://op.europa.eu/en/web/eu-vocabularies/concept-scheme/-/resource?uri=http://publications.europa.eu/resource/authority/dataset-type).",
+    type: "Datasettets spesifikke type. Dette kan velges blant EU's kontrollerte vokabular [dataset type](https://op.europa.eu/en/web/eu-vocabularies/concept-scheme/-/resource?uri=http://publications.europa.eu/resource/authority/dataset-type).",
     provenance:
       "Endringer i eierskap eller forvaltning av datasettet, dersom dette har betydning for autentisitet, integritet og fortolkning.",
     frequency:
-      "Hvor ofte datasettet har nytt innhold. Verdien velges fra EU’s kontrollerte vokabular [frequency](https://op.europa.eu/en/web/eu-vocabularies/concept-scheme/-/resource?uri=http://publications.europa.eu/resource/authority/frequency)",
+      "Hvor ofte datasettet har nytt innhold. Verdien velges fra EU's kontrollerte vokabular [frequency](https://op.europa.eu/en/web/eu-vocabularies/concept-scheme/-/resource?uri=http://publications.europa.eu/resource/authority/frequency)",
     modified: "Dato for siste oppdatering av datasettet.",
     currentness: "Tilleggsopplysninger om oppdateringsfrekvens.",
     completeness:
@@ -123,7 +123,7 @@ Dersom man velger en åpen lisens, vil datasettet bli merket med "Åpne data".`,
     theme:
       "Det eller de mest sentrale områdene innholdet i datasettet kan kategoriseres under. Tema kan hjelpe andre med å finne presise resultater i filtrerte søk.",
     distributions:
-      "Informasjon som gjør det mulig for andre å ta i bruk selve datasettet. ",
+      "Informasjon som gjør det mulig for andre å ta i bruk selve datasettet.",
     details:
       "Opplysninger som videre beskriver datasettet. Dette vil hjelpe datakonsumenter med å vurdere om datasettet er aktuelt for deres formål.",
     relations:
@@ -204,16 +204,16 @@ Dersom man velger en åpen lisens, vil datasettet bli merket med "Åpne data".`,
     ignoreRequired:
       "I utgangspunktet er det krav om at alle påkrevde felt må fylles ut for å få lagret. Når avhukingsboksen er aktiv, må bare tittel være fylt ut.",
     unpublishBeforeUnapprove:
-      "Datasettet må være avpublisert før status kan endres fra ‘Godkjent’. Avpublisering gjøres fra detaljsiden.",
+      "Datasettet må være avpublisert før status kan endres fra 'Godkjent'. Avpublisering gjøres fra detaljsiden.",
     unpublishBeforeIgnoreRequired:
-      "Datasettet må være avpublisert for å kunne aktivere ‘Ignorer påkrevde felt’. Avpublisering gjøres fra detaljsiden.",
+      "Datasettet må være avpublisert for å kunne aktivere 'Ignorer påkrevde felt'. Avpublisering gjøres fra detaljsiden.",
   },
   validation: {
     title: "Tittelen må være minst 3 karakterer lang.",
     titleRequired: "Tittel er påkrevd.",
     descriptionRequired: "Beskrivelse er påkrevd.",
     description: "Beskrivelsen må være minst 5 karakterer lang.",
-    url: "Ugyldig lenke. Vennligst sørg for at lenken starter med ‘https://’ og inneholder et gyldig toppdomene (f.eks. ‘.no’).",
+    url: "Ugyldig lenke. Vennligst sørg for at lenken starter med 'https://' og inneholder et gyldig toppdomene (f.eks. '.no').",
     euDataTheme: "Minst ett EU-tema må være valgt.",
     searchString: "Ingen treff. Søkestrengen må inneholde minst to bokstaver.",
     accessURL: "Tilgangslenke er påkrevd.",

--- a/libs/utils/src/lib/language/helptexts.concept.nb.ts
+++ b/libs/utils/src/lib/language/helptexts.concept.nb.ts
@@ -15,14 +15,14 @@ export const conceptHelptextsNb = {
     "En definisjon av begrepet som er rettet mot allmennheten. Det forventes ikke at denne målgruppen har noe forkunnskap i det/de aktuelle fagområdet/fagområdene for begrepet.",
   definisjonForAllmennhetenKildeTitle: "Kilde til definisjon for allmennheten",
   definisjonForAllmennhetenKildeDescription:
-    "Her oppgir du hvor du har hentet definisjonen fra. ",
+    "Her oppgir du hvor du har hentet definisjonen fra.",
 
   definisjonForSpesialisterTitle: "Definisjon for spesialister",
   definisjonForSpesialisterDescription:
     "En definisjon av begrepet som er rettet mot spesialister. for jurister skal være en kort beskrivelse som tydelig avgrenser til andre, nærliggende begrep, eventuelt tydeliggjør forskjellen mellom dette begrepet og andre nærliggende begrep.",
   definisjonForSpesialisterKildeTitle: "Kilde til definisjon for spesialister",
   definisjonForSpesialisterKildeDescription:
-    "Her registrerer du hvor du har hentet definisjonen fra. ",
+    "Her registrerer du hvor du har hentet definisjonen fra.",
 
   merknadTitle: "Merknad",
   merknadDescription:

--- a/libs/utils/src/lib/language/nb.ts
+++ b/libs/utils/src/lib/language/nb.ts
@@ -386,7 +386,8 @@ rettigheter, eller at det har oppstått en feil ved henting av tilganger. Vennli
     basedOnSource: "Basert på kilde",
     concept: "Begrep",
     concepts: "Begreper",
-    confirmDelete: "Du er i ferd med å slette begrepet **{0}**. All historikk og endringsforslag knyttet til begrepet vil bli permanent slettet, og slettingen kan ikke angres. Er du sikker på at du vil fortsette?",
+    confirmDelete:
+      "Du er i ferd med å slette begrepet **{0}**. All historikk og endringsforslag knyttet til begrepet vil bli permanent slettet, og slettingen kan ikke angres. Er du sikker på at du vil fortsette?",
     confirmEditWithChangeRequest:
       "Det finnes et åpent endringsforslag for dette begrepet. Er du sikker på at du vil redigere begrepet?",
     contactInformation: "Kontaktinformasjon for eksterne",
@@ -561,8 +562,10 @@ ___Merk:__ Maksimal filstørrelse for opplastning er {0} MB. CSV/JSON-filer kan 
   validation: {
     invalidValue: "Ugyldig verdi",
     invalidEmail: "Ugyldig epostadresse",
-    invalidUrl: "Ugyldig lenke. Vennligst sørg for at lenken har en gyldig adresse, og ender med et toppdomene (f.eks. ‘.no’).",
-    invalidProtocol: "Ugyldig lenke. Vennligst sørg for at lenken starter med ‘https://’.",
+    invalidUrl:
+      "Ugyldig lenke. Vennligst sørg for at lenken har en gyldig adresse, og ender med et toppdomene (f.eks. '.no').",
+    invalidProtocol:
+      "Ugyldig lenke. Vennligst sørg for at lenken starter med 'https://'.",
     invalidPhone: "Ugyldig telefonnummer.",
     multipleInvalidValues: "Inneholder en eller flere ugyldige verdier",
     nameRequired: "Må ha navn",
@@ -643,7 +646,8 @@ ___Merk:__ Maksimal filstørrelse for opplastning er {0} MB. CSV/JSON-filer kan 
     pageTitle: "Vilkår og betingelser",
     heading: "Bruksvilkår for registrering i Felles datakatalog",
     notAcceptedTitle: "Bruksvilkår ikke akseptert",
-    notAcceptedContent: "Bruksvilkår må aksepteres for å kunne ta i bruk katalogtjenestene. Hvis vilkårene nylig har blitt akseptert må du logge ut og inn igjen for at det skal tre i kraft. ",
+    notAcceptedContent:
+      "Bruksvilkår må aksepteres for å kunne ta i bruk katalogtjenestene. Hvis vilkårene nylig har blitt akseptert må du logge ut og inn igjen for at det skal tre i kraft.",
     gotoTermsOfUse: "Gå til bruksvilkår",
     cancel: "Avbryt",
     adminPermissionNeeded:
@@ -676,9 +680,10 @@ ___Merk:__ Maksimal filstørrelse for opplastning er {0} MB. CSV/JSON-filer kan 
     deleteImport: "Slett",
     confirmImport: "Legg til i katalog",
     tryAgain: "Prøv igjen",
-    deleteCanResultInDuplicates: "Sletting av denne kan resultere i duplikater hvis samme import gjennomføres senere.",
+    deleteCanResultInDuplicates:
+      "Sletting av denne kan resultere i duplikater hvis samme import gjennomføres senere.",
     cancelledImport: "Importen ble avvist før den ble fullført.",
-    conceptId: "Begreps-ID ",
+    conceptId: "Begreps-ID",
     recordStatus: {
       addToCatalog: "Klar til i katalog",
       addedToCatalog: "Lagt til i katalog",


### PR DESCRIPTION
Fikser unicode-advarsel: The character U+2018 | U+2019 "’" could be confused with the ASCII character U+0060 "`", which is more common in source code.