### PR TITLE
fix: remove costs property when array is empty

### DIFF
--- a/apps/data-service-catalog/components/data-service-form/components/costs-table.tsx
+++ b/apps/data-service-catalog/components/data-service-form/components/costs-table.tsx
@@ -80,7 +80,7 @@ export const CostsTable = ({ currencies }: Props) => {
 
   const handleDeleteCost = (index: number) => () => {
     const newCosts = values.costs?.filter((_, i) => i !== index);
-    setFieldValue("costs", newCosts?.length ? newCosts : undefined);
+    setFieldValue("costs", newCosts?.length ? newCosts : []);
   };
 
   return (


### PR DESCRIPTION
## Summary fixes #1624

- Fix costs array deletion to remove property when empty instead of leaving `[null]`
- Add `handleDeleteCost` handler that filters out deleted items
- Set `costs` to `undefined` when last item is removed