### PR TITLE
Håndterer ingen endring uten å kaste feil

### DIFF
--- a/apps/concept-catalog/app/actions/concept/actions.ts
+++ b/apps/concept-catalog/app/actions/concept/actions.ts
@@ -186,7 +186,7 @@ export async function updateConcept(
   const diff = conceptJsonPatchOperations(initialConcept, values);
 
   if (diff.length === 0) {
-    throw new Error(localization.alert.noChanges);
+    return initialConcept;
   }
 
   let success = false;

--- a/apps/data-service-catalog/app/actions/actions.ts
+++ b/apps/data-service-catalog/app/actions/actions.ts
@@ -152,7 +152,7 @@ export async function updateDataService(
   );
 
   if (diff.length === 0) {
-    throw new Error(localization.alert.noChanges);
+    return initialDataService;
   }
 
   let success = false;

--- a/apps/dataset-catalog/app/actions/actions.ts
+++ b/apps/dataset-catalog/app/actions/actions.ts
@@ -125,7 +125,7 @@ export async function updateDataset(
   const diff = compare(initialDataset, updatedDataset);
 
   if (diff.length === 0) {
-    throw new Error(localization.alert.noChanges);
+    return;
   }
 
   let success = false;
@@ -164,7 +164,7 @@ export async function publishDataset(
   const diff = compare(initialDataset, values);
 
   if (diff.length === 0) {
-    throw new Error(localization.alert.noChanges);
+    return;
   }
 
   const session = await getValidSession();

--- a/apps/service-catalog/app/actions/public-services/actions.ts
+++ b/apps/service-catalog/app/actions/public-services/actions.ts
@@ -144,7 +144,7 @@ export async function updatePublicService(
   const diff = compare(oldPublicService, updatedPublicServiceMerged);
 
   if (diff.length === 0) {
-    throw new Error(localization.alert.noChanges);
+    return;
   }
 
   let success = false;

--- a/apps/service-catalog/app/actions/services/actions.ts
+++ b/apps/service-catalog/app/actions/services/actions.ts
@@ -142,7 +142,7 @@ export async function updateService(
   const diff = compare(oldService, updatedServiceMerged);
 
   if (diff.length === 0) {
-    throw new Error(localization.alert.noChanges);
+    return;
   }
 
   let success = false;


### PR DESCRIPTION
Håndterer ingen endring uten å kaste feil.

Fixes https://github.com/Informasjonsforvaltning/catalog-frontend/issues/1569