### PR TITLE
fix: use correct catalog type in data-service-catalog

### DIFF
--- a/apps/data-service-catalog/app/catalogs/[catalogId]/no-access/page.tsx
+++ b/apps/data-service-catalog/app/catalogs/[catalogId]/no-access/page.tsx
@@ -30,7 +30,7 @@ const NoAccess = async ({
         catalogPortalUrl={`${process.env.CATALOG_PORTAL_BASE_URI}/catalogs`}
       />
       <PageBanner
-        title={localization.catalogType.dataset}
+        title={localization.catalogType.dataService}
         subtitle={localization.noAccess}
       />
       <CenterContainer>

--- a/apps/data-service-catalog/app/not-found/page.tsx
+++ b/apps/data-service-catalog/app/not-found/page.tsx
@@ -22,7 +22,7 @@ const NotFound = async () => {
         catalogPortalUrl={`${process.env.CATALOG_PORTAL_BASE_URI}/catalogs`}
       />
       <PageBanner
-        title={localization.catalogType.dataset}
+        title={localization.catalogType.dataService}
         subtitle={localization.notFound}
       />
       <CenterContainer>

--- a/apps/data-service-catalog/components/catalog-layout/index.tsx
+++ b/apps/data-service-catalog/components/catalog-layout/index.tsx
@@ -42,7 +42,7 @@ export const CatalogLayout = ({
       termsOfUseUrl={`${fdkRegistrationBaseUrl}/terms-and-conditions/${catalogId}`}
       adminGuiBaseUrl={adminGuiBaseUrl}
       fdkBaseUrl={fdkBaseUrl}
-      catalogTitle={localization.catalogType.dataset}
+      catalogTitle={localization.catalogType.dataService}
       displayFooter={false}
     >
       {children}


### PR DESCRIPTION
# Summary fixes #1672

- Fix catalog type label from "dataset" to "dataService" on no-access page
- Fix catalog type label on not-found page
- Fix catalog type label in catalog layout component