### PR TITLE
fix: correct catalog type labels in service-catalog

### DIFF
--- a/apps/service-catalog/app/catalogs/[catalogId]/no-access/page.tsx
+++ b/apps/service-catalog/app/catalogs/[catalogId]/no-access/page.tsx
@@ -30,7 +30,7 @@ const NoAccess = async ({ params }: Props) => {
         catalogPortalUrl={`${process.env.CATALOG_PORTAL_BASE_URI}/catalogs`}
       />
       <PageBanner
-        title={localization.catalogType.concept}
+        title={localization.catalogType.service}
         subtitle={localization.error}
       />
       <CenterContainer>

--- a/apps/service-catalog/app/catalogs/[catalogId]/public-services/[serviceId]/edit/page.tsx
+++ b/apps/service-catalog/app/catalogs/[catalogId]/public-services/[serviceId]/edit/page.tsx
@@ -44,7 +44,7 @@ export default async function EditServicePage({
         catalogPortalUrl={`${process.env.CATALOG_PORTAL_BASE_URI}/catalogs`}
       />
       <PageBanner
-        title={localization.catalogType.service}
+        title={localization.catalogType.publicService}
         subtitle={getTranslateText(organization?.prefLabel)}
       />
       <EditPage

--- a/apps/service-catalog/app/notfound/page.tsx
+++ b/apps/service-catalog/app/notfound/page.tsx
@@ -22,7 +22,7 @@ const NotFound = async () => {
         catalogPortalUrl={`${process.env.CATALOG_PORTAL_BASE_URI}/catalogs`}
       />
       <PageBanner
-        title={localization.catalogType.concept}
+        title={localization.catalogType.service}
         subtitle={localization.notFound}
       />
       <CenterContainer>


### PR DESCRIPTION
# Summary fixes #1674

- Fix notfound and no-access pages showing "Begrep" instead of "Tjeneste"
- Fix public-services edit page showing "Tjeneste" instead of "Offentlig tjeneste"