### PR TITLE
chore: upgrade dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "postcss-flexbugs-fixes": "^5.0.2",
     "postcss-import": "^16.1.1",
     "postcss-preset-env": "^10.4.0",
-    "react": "19.2.3",
+    "react": "19.2.4",
     "react-arborist": "^3.4.3",
     "react-dom": "19.2.4",
     "react-is": "19.2.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9756,7 +9756,7 @@ __metadata:
     postcss-import: "npm:^16.1.1"
     postcss-preset-env: "npm:^10.4.0"
     prettier: "npm:3.6.2"
-    react: "npm:19.2.3"
+    react: "npm:19.2.4"
     react-arborist: "npm:^3.4.3"
     react-dom: "npm:19.2.4"
     react-is: "npm:19.2.4"
@@ -19297,10 +19297,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react@npm:19.2.3":
-  version: 19.2.3
-  resolution: "react@npm:19.2.3"
-  checksum: 10/d16b7f35c0d35a56f63d9d1693819762e4abc479c57dd6310298920bed3820fcec7e17a99d44983416d8f5049143ea45b8005d3ab8324bae8973224400502b08
+"react@npm:19.2.4":
+  version: 19.2.4
+  resolution: "react@npm:19.2.4"
+  checksum: 10/18179fe217f67eb2d0bc61cd04e7ad3c282ea09a1dface7eacd71816f62609f4bbf566c447c704335284deb8397b00bca084e0cd60e6f437279a7498e2d0bfe0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Summary 

- Upgrade Next.js to 16.1.6
- Upgrade TypeScript ESLint to 8.55.0
- Upgrade Playwright to 1.58.2
- Upgrade React DOM and React IS to 19.2.4
- Upgrade GraphQL to 16.12.0
- Upgrade nuqs to 2.8.8