### PR TITLE
fix: add response.ok check to org API

### DIFF
--- a/libs/data-access/src/lib/organization/api/index.ts
+++ b/libs/data-access/src/lib/organization/api/index.ts
@@ -33,6 +33,13 @@ export const getOrganizations = async (
     cache: "no-cache" as RequestCache,
   };
   const response = await fetch(resource, options);
+
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch organizations: ${response.status} ${response.statusText}`,
+    );
+  }
+
   return response.json();
 };
 
@@ -56,5 +63,12 @@ export const getOrganization = async (
     cache: "no-cache" as RequestCache,
   };
   const response = await fetch(resource, options);
+
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch organization: ${response.status} ${response.statusText}`,
+    );
+  }
+
   return response.json();
 };


### PR DESCRIPTION
# Summary fixes #1685

- Add response.ok check before calling response.json() in `getOrganizations` and `getOrganization`
- Throw descriptive error with status code instead of cryptic SyntaxError