### PR TITLE
fix: migrate ui-v2 CSS tokens from --fds-* to --ds-* for designsystemet v1.11.1

### DIFF
--- a/libs/ui-v2/src/lib/button-bar/button-bar.module.scss
+++ b/libs/ui-v2/src/lib/button-bar/button-bar.module.scss
@@ -1,6 +1,6 @@
 .buttonBar {
   display: flex;
-  gap: var(--fds-spacing-4);
+  gap: var(--ds-size-4);
   justify-content: space-between;
-  padding: var(--fds-spacing-4);
+  padding: var(--ds-size-4);
 }

--- a/libs/ui-v2/src/lib/form-container/form-container.module.css
+++ b/libs/ui-v2/src/lib/form-container/form-container.module.css
@@ -25,7 +25,7 @@
   flex-direction: column;
   padding: 1.5em 2em;
   gap: 0.25em;
-  background: var(--fds-semantic-surface-third-light);
+  background: var(--ds-color-accent-background-tinted);
 }
 
 .header.secondary {

--- a/libs/ui-v2/src/lib/form-layout/form-layout.module.scss
+++ b/libs/ui-v2/src/lib/form-layout/form-layout.module.scss
@@ -52,8 +52,8 @@
     align-items: center;
 
     &.active {
-      background-color: var(--fds-semantic-surface-third-light);
-      border-left: 4px solid var(--fds-semantic-surface-action-default);
+      background-color: var(--ds-color-accent-background-tinted);
+      border-left: 4px solid var(--ds-color-accent-base-default);
 
       :global(.fds-link) {
         color: black;
@@ -67,13 +67,13 @@
     & .required {
       font-size: medium;
       font-style: italic;
-      color: var(--fds-colors-grey-700);
+      color: var(--ds-color-neutral-text-subtle);
     }
 
     &:hover {
-      border-left: 4px solid var(--fds-semantic-surface-action-default);
-      background: var(--fds-semantic-surface-action-first-no_fill-hover);
-      color: var(--fds-colors-gray-800);
+      border-left: 4px solid var(--ds-color-accent-base-default);
+      background: var(--ds-color-accent-surface-hover);
+      color: var(--ds-color-neutral-text-default);
     }
 
     :global(.fds-link) {
@@ -90,7 +90,7 @@
       }
 
       &:hover {
-        background: var(--fds-semantic-surface-action-first-no_fill-hover);
+        background: var(--ds-color-accent-surface-hover);
       }
     }
   }
@@ -101,10 +101,10 @@
 }
 
 .sideMenuFooter {
-  padding-top: var(--fds-spacing-2);
+  padding-top: var(--ds-size-2);
   font-size: small;
   font-style: italic;
-  color: var(--fds-colors-grey-700);
+  color: var(--ds-color-neutral-text-subtle);
 }
 
 .section {

--- a/libs/ui-v2/src/lib/formik-language-fieldset/formik-language-fieldset.module.scss
+++ b/libs/ui-v2/src/lib/formik-language-fieldset/formik-language-fieldset.module.scss
@@ -1,7 +1,7 @@
 .fieldset {
   & :global(.fds-fieldset__legend__content) {
     align-items: center;
-    gap: var(--fds-spacing-1);
+    gap: var(--ds-size-1);
   }
 }
 

--- a/libs/ui-v2/src/lib/formik-multivalue-textfield/formik-multivalue-textfield.module.scss
+++ b/libs/ui-v2/src/lib/formik-multivalue-textfield/formik-multivalue-textfield.module.scss
@@ -21,5 +21,5 @@
 .chipGroup {
   display: flex;
   flex-wrap: wrap;
-  margin-top: var(--fds-spacing-2);
+  margin-top: var(--ds-size-2);
 }

--- a/libs/ui-v2/src/lib/formik-optional-fields-fieldset/formik-optional-fields-fieldset.module.scss
+++ b/libs/ui-v2/src/lib/formik-optional-fields-fieldset/formik-optional-fields-fieldset.module.scss
@@ -1,7 +1,7 @@
 .fieldset {
   & :global(.fds-fieldset__legend__content) {
     align-items: center;
-    gap: var(--fds-spacing-1);
+    gap: var(--ds-size-1);
   }
 }
 

--- a/libs/ui-v2/src/lib/header/header.module.scss
+++ b/libs/ui-v2/src/lib/header/header.module.scss
@@ -124,7 +124,7 @@
 .menuButton {
   color: currentColor;
   &:hover {
-    color: var(--fds-semantic-text-neutral-default);
+    color: var(--ds-color-neutral-text-default);
   }
 }
 

--- a/libs/ui-v2/src/lib/help-markdown/help-markdown.module.scss
+++ b/libs/ui-v2/src/lib/help-markdown/help-markdown.module.scss
@@ -1,10 +1,10 @@
 .helpMarkdown {
   --helpmarkdown-icon-size: 65%;
   --helpmarkdown-icon-url: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' aria-label='info ikon' fill='none' viewBox='0 0 8 14'%3E%3Cpath fill='%23000' fill-rule='evenodd' d='M4 11a1.5 1.5 0 1 1 0 3 1.5 1.5 0 0 1 0-3ZM4 0c2.2 0 4 1.66 4 3.7 0 .98-.42 1.9-1.17 2.6l-.6.54-.29.29c-.48.46-.87.93-.94 1.41V9.5H3v-.81c0-1.26.84-2.22 1.68-3L5.42 5C5.8 4.65 6 4.2 6 3.7 6 2.66 5.1 1.83 4 1.83c-1.06 0-1.92.75-2 1.7v.15H0C0 1.66 1.8 0 4 0Z' clip-rule='evenodd'/%3E%3C/svg%3E");
-  --helpmarkdown-size: var(--fds-sizing-6);
+  --helpmarkdown-size: var(--ds-size-6);
 
-  border-radius: var(--fds-border_radius-full);
-  border: max(1px, calc(var(--fds-sizing-1) / 2)) solid; /* Allow border-width to grow with font-size */
+  border-radius: var(--ds-border-radius-full);
+  border: max(1px, calc(var(--ds-size-1) / 2)) solid; /* Allow border-width to grow with font-size */
   box-sizing: border-box;
   height: var(--helpmarkdown-size);
   min-height: 0;
@@ -52,7 +52,7 @@
   --helpmarkdown-icon-url: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' aria-label='advarsel ikon' width='1em' height='1em' fill='none' viewBox='0 0 24 24' focusable='false' role='img'%3E%3Cpath fill='currentColor' fill-rule='evenodd' d='M12 2.25a.75.75 0 0 1 .656.387l9.527 17.25A.75.75 0 0 1 21.526 21H2.474a.75.75 0 0 1-.657-1.113l9.527-17.25A.75.75 0 0 1 12 2.25m8.255 17.25L12 4.551 3.745 19.5zM12 8.75a.75.75 0 0 1 .75.75v4a.75.75 0 0 1-1.5 0v-4a.75.75 0 0 1 .75-.75m0 6.75a1 1 0 1 0 0 2 1 1 0 0 0 0-2' clip-rule='evenodd'%3E%3C/path%3E%3C/svg%3E");
 
   border: none;
-  color: var(--fds-semantic-border-warning-default);
+  color: var(--ds-color-warning-border-default);
 }
 
 .danger {
@@ -60,18 +60,18 @@
   --helpmarkdown-icon-url: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' aria-label='feil ikon' width='1em' height='1em' fill='none' viewBox='0 0 24 24' focusable='false' role='img'%3E%3Cpath fill='currentColor' fill-rule='evenodd' d='M8.272 2.25a.75.75 0 0 0-.53.22L2.47 7.742a.75.75 0 0 0-.22.53v7.456c0 .199.079.39.22.53l5.272 5.272c.14.141.331.22.53.22h7.456a.75.75 0 0 0 .53-.22l5.272-5.272a.75.75 0 0 0 .22-.53V8.272a.75.75 0 0 0-.22-.53L16.258 2.47a.75.75 0 0 0-.53-.22zM3.75 8.583 8.583 3.75h6.834l4.833 4.833v6.834l-4.833 4.833H8.583L3.75 15.417zm5.28-.613a.75.75 0 0 0-1.06 1.06L10.94 12l-2.97 2.97a.75.75 0 1 0 1.06 1.06L12 13.06l2.97 2.97a.75.75 0 1 0 1.06-1.06L13.06 12l2.97-2.97a.75.75 0 0 0-1.06-1.06L12 10.94z' clip-rule='evenodd'%3E%3C/path%3E%3C/svg%3E");
 
   border: none;
-  color: var(--fds-semantic-border-danger-default);
+  color: var(--ds-color-danger-border-default);
 }
 
 .markdownContent {
-  font: var(--fds-typography-paragraph-small);
+  font-size: var(--ds-font-size-2);
 
   p {
-    margin-bottom: var(--fds-spacing-2);
+    margin-bottom: var(--ds-size-2);
   }
 
   li {
-    margin-bottom: var(--fds-spacing-1);
+    margin-bottom: var(--ds-size-1);
   }
 
   strong {

--- a/libs/ui-v2/src/lib/import-result-details/components/import-record-accordion-item/import-record-accordion-item.module.css
+++ b/libs/ui-v2/src/lib/import-result-details/components/import-record-accordion-item/import-record-accordion-item.module.css
@@ -23,9 +23,9 @@
 }
 
 .errorIcon {
-  color: var(--fds-semantic-text-danger-default);
+  color: var(--ds-color-danger-text-default);
 }
 
 .warningIcon {
-  color: var(--fds-semantic-text-warning-icon_warning);
+  color: var(--ds-color-warning-text-subtle);
 }

--- a/libs/ui-v2/src/lib/import-results-table/import-results-table.module.css
+++ b/libs/ui-v2/src/lib/import-results-table/import-results-table.module.css
@@ -7,15 +7,15 @@
 }
 
 .successIcon {
-  color: var(--fds-semantic-text-success-default);
+  color: var(--ds-color-success-text-default);
 }
 
 .errorIcon {
-  color: var(--fds-semantic-text-danger-default);
+  color: var(--ds-color-danger-text-default);
 }
 
 .warningIcon {
-  color: var(--fds-semantic-text-warning-icon_warning);
+  color: var(--ds-color-warning-text-subtle);
 }
 
 .titleTags {

--- a/libs/ui-v2/src/lib/new-dataset-modal/new-dataset-modal.module.scss
+++ b/libs/ui-v2/src/lib/new-dataset-modal/new-dataset-modal.module.scss
@@ -2,15 +2,15 @@
   display: flex;
   flex-direction: column;
   gap: 1rem;
-  padding-left: var(--fds-spacing-10, 2.5rem);
-  padding-right: var(--fds-spacing-10, 2.5rem);
-  padding-bottom: var(--fds-spacing-8, 2.5rem);
+  padding-left: var(--ds-size-10, 2.5rem);
+  padding-right: var(--ds-size-10, 2.5rem);
+  padding-bottom: var(--ds-size-8, 2.5rem);
 }
 
 .header {
-  padding-left: var(--fds-spacing-10, 2.5rem);
-  padding-right: var(--fds-spacing-10, 2.5rem);
-  padding-bottom: var(--fds-spacing-2, 2.5rem);
+  padding-left: var(--ds-size-10, 2.5rem);
+  padding-right: var(--ds-size-10, 2.5rem);
+  padding-bottom: var(--ds-size-2, 2.5rem);
 }
 
 .intro {
@@ -30,9 +30,9 @@
   display: flex !important;
   flex-direction: column;
   gap: 0.5rem;
-  padding: var(--fds-spacing-6, 1.5rem);
-  border: 1px solid var(--fds-semantic-border-neutral-default);
-  border-radius: var(--fds-border_radius-medium, 0.5rem);
+  padding: var(--ds-size-6, 1.5rem);
+  border: 1px solid var(--ds-color-neutral-border-default);
+  border-radius: var(--ds-border-radius-md, 0.5rem);
   width: auto;
 }
 
@@ -49,7 +49,7 @@
 
 .optionDescription {
   font-size: 1rem;
-  color: var(--fds-semantic-text-neutral-subtle);
+  color: var(--ds-color-neutral-text-subtle);
   margin: 0;
   margin-bottom: 0.5rem;
 }

--- a/libs/ui-v2/src/lib/search-field/search-field.module.scss
+++ b/libs/ui-v2/src/lib/search-field/search-field.module.scss
@@ -11,7 +11,7 @@
   right: 0.5rem;
   bottom: 0.5rem;
   display: flex;
-  gap: var(--fds-spacing-2);
+  gap: var(--ds-size-2);
 }
 
 .searchButton {

--- a/libs/ui-v2/src/lib/search-hits-layout/search-hits-layout.module.css
+++ b/libs/ui-v2/src/lib/search-hits-layout/search-hits-layout.module.css
@@ -4,14 +4,14 @@
   flex-direction: column;
   width: 100%;
   margin: 0 auto;
-  padding: var(--fds-spacing-6) 0;
+  padding: var(--ds-size-6) 0;
   overflow-wrap: break-word;
 }
 
 .searchRowContainer {
   display: flex;
   flex-direction: column;
-  margin-bottom: var(--fds-spacing-6);
+  margin-bottom: var(--ds-size-6);
 }
 
 .gridContainer {

--- a/libs/ui-v2/src/lib/snackbar/snackbar.module.scss
+++ b/libs/ui-v2/src/lib/snackbar/snackbar.module.scss
@@ -1,7 +1,7 @@
 .snackbar {
   position: fixed;
   bottom: 65px;
-  margin: var(--fds-spacing-2);
+  margin: var(--ds-size-2);
 }
 
 .snackbarItem {
@@ -20,7 +20,7 @@
     align-items: center;
     flex-direction: row;
     flex-grow: 1;
-    gap: var(--fds-spacing-4);
+    gap: var(--ds-size-4);
   }
 
   :global(.fds-btn) {

--- a/libs/ui-v2/src/lib/terms-of-use/components/terms-of-use-alert/terms-of-use-alert.module.scss
+++ b/libs/ui-v2/src/lib/terms-of-use/components/terms-of-use-alert/terms-of-use-alert.module.scss
@@ -1,3 +1,3 @@
 .buttonRow {
-  margin-top: var(--fds-spacing-2);
+  margin-top: var(--ds-size-2);
 }

--- a/libs/ui-v2/src/lib/textarea-with-prefix/textarea-with-prefix.module.scss
+++ b/libs/ui-v2/src/lib/textarea-with-prefix/textarea-with-prefix.module.scss
@@ -1,31 +1,31 @@
 .textareaWithPrefix {
   display: flex;
   flex-direction: column;
-  gap: var(--fds-spacing-2);
+  gap: var(--ds-size-2);
 
   & label {
     display: inline-block;
     margin: 0;
     padding: 0;
-    color: var(--fds-semantic-text-neutral-default);
-    font: var(--fds-typography-label-small);
+    color: var(--ds-color-neutral-text-default);
+    font-size: var(--ds-font-size-2);
     font-family: inherit;
     font-weight: 500;
   }
 
   & .prefix {
-    border: 1px solid var(--fds-semantic-border-neutral-default);
-    border-top-left-radius: var(--fds-border_radius-medium);
-    border-top-right-radius: var(--fds-border_radius-medium);
+    border: 1px solid var(--ds-color-neutral-border-default);
+    border-top-left-radius: var(--ds-border-radius-md);
+    border-top-right-radius: var(--ds-border-radius-md);
     padding: 0;
-    background: var(--fds-semantic-surface-neutral-subtle);
-    color: var(--fds-semantic-border-neutral-default);
+    background: var(--ds-color-neutral-surface-tinted);
+    color: var(--ds-color-neutral-border-default);
     display: flex;
     justify-content: space-between;
 
     & > p {
-      padding: 0.65rem var(--fds-spacing-4);
-      color: var(--fds-semantic-border-neutral-default);
+      padding: 0.65rem var(--ds-size-4);
+      color: var(--ds-color-neutral-border-default);
     }
 
     & > * {


### PR DESCRIPTION
# Summary fixes #1693

- Migrert alle `--fds-*` CSS tokens til `--ds-*` i 16 filer under `libs/ui-v2/`
- Spacing: `--fds-spacing-N` → `--ds-size-N`
- Farger: `--fds-semantic-*` → `--ds-color-*`
- Border-radius: `--fds-border_radius-*` → `--ds-border-radius-*`
- Typografi: `--fds-typography-*` → `--ds-font-size-*`