### PR TITLE
fix: delay render of AccordionItem until after hydration

### DIFF
--- a/libs/ui-v2/src/lib/accordion-item/index.tsx
+++ b/libs/ui-v2/src/lib/accordion-item/index.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Details } from "@digdir/designsystemet-react";
-import { ReactNode, useState } from "react";
+import { ReactNode, useState, useEffect } from "react";
 
 export type AccordionItemProps = {
   header: ReactNode;
@@ -15,6 +15,15 @@ const AccordionItem = ({
   initiallyOpen = false,
 }: AccordionItemProps) => {
   const [isOpen, setIsOpen] = useState(initiallyOpen);
+  const [isMounted, setIsMounted] = useState(false);
+
+  useEffect(() => {
+    setIsMounted(true);
+  }, []);
+
+  if (!isMounted) {
+    return null;
+  }
 
   return (
     <Details open={isOpen} onToggle={() => setIsOpen(!isOpen)}>


### PR DESCRIPTION
Får denne feilmeldingen i api-katalogen:
````
A tree hydrated but some attributes of the server rendered HTML didn't match the client properties. This won't be patched up. This can happen if a SSR-ed Client Component used:

- A server/client branch `if (typeof window !== 'undefined')`.
- Variable input such as `Date.now()` or `Math.random()` which changes each time it's called.
- Date formatting in a user's locale which doesn't match the server.
- External changing data without sending a snapshot of it along with the HTML.
- Invalid HTML tag nesting.

It can also happen if the client has a browser extension installed which messes with the HTML before React loaded.

https://react.dev/link/hydration-mismatch
````

Ser ut til å hjelpe å bare utsette render