### PR TITLE
feat: load Inter font from altinncdn

### DIFF
--- a/libs/ui-v2/src/lib/layout/global.css
+++ b/libs/ui-v2/src/lib/layout/global.css
@@ -1,5 +1,6 @@
 /* This is a global stylesheet */
 
+@import url("https://altinncdn.no/fonts/inter/v4.1/inter.css");
 @import url("./reset.css");
 @layer reset, ds;
 
@@ -8,6 +9,7 @@ html * {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   font-family:
+    "Inter",
     system-ui,
     -apple-system,
     BlinkMacSystemFont,


### PR DESCRIPTION
# Summary fixes #1697

- Load Inter v4.1 from altinncdn in ui-v2 global CSS
- Set "Inter" as primary font-family with system font fallbacks