### PR TITLE
fix: restore hamburger menu button appearance

### DIFF
--- a/libs/ui-v2/src/lib/header/header.module.scss
+++ b/libs/ui-v2/src/lib/header/header.module.scss
@@ -123,8 +123,11 @@
 
 .menuButton {
   color: currentColor;
+  --dsc-button-color: currentColor;
+  --dsc-button-color--hover: currentColor;
   &:hover {
     color: var(--ds-color-neutral-text-default);
+    --dsc-button-color--hover: var(--ds-color-neutral-text-default);
   }
 }
 

--- a/libs/ui-v2/src/lib/header/index.tsx
+++ b/libs/ui-v2/src/lib/header/index.tsx
@@ -133,7 +133,7 @@ const Header: FC<HeaderProps> = ({
         </a>
         {userDisplayName && (
           <Dropdown.TriggerContext>
-            <Dropdown.Trigger className={styles.menuButton}>
+            <Dropdown.Trigger variant="tertiary" className={styles.menuButton}>
               <MenuHamburgerIcon aria-hidden fontSize="1.5rem" />
               {localization.header.menu}
             </Dropdown.Trigger>


### PR DESCRIPTION
# Summary fixes #1699

- Add `variant="tertiary"` to `Dropdown.Trigger` to remove unwanted blue background
- Override `--dsc-button-color` CSS tokens to inherit white color from dark header context