### PR TITLE
fix(ui-v2): pre-set Details web component attributes to prevent hydration mismatch

### DIFF
--- a/libs/ui-v2/src/lib/accordion-item/index.tsx
+++ b/libs/ui-v2/src/lib/accordion-item/index.tsx
@@ -17,8 +17,15 @@ const AccordionItem = ({
   const [isOpen, setIsOpen] = useState(initiallyOpen);
 
   return (
-    <Details open={isOpen} onToggle={() => setIsOpen(!isOpen)}>
-      <Details.Summary>{header}</Details.Summary>
+    <Details open={isOpen} onToggle={() => setIsOpen(!isOpen)} role="group">
+      <Details.Summary
+        role="button"
+        slot="summary"
+        tabIndex={0}
+        aria-expanded={isOpen}
+      >
+        {header}
+      </Details.Summary>
       <Details.Content>{content}</Details.Content>
     </Details>
   );

--- a/libs/ui-v2/src/lib/import-result-details/components/import-record-accordion-item/index.tsx
+++ b/libs/ui-v2/src/lib/import-result-details/components/import-record-accordion-item/index.tsx
@@ -73,8 +73,13 @@ const ImportRecordAccordionItem = ({
   };
 
   return (
-    <Details>
-      <Details.Summary>
+    <Details role="group">
+      <Details.Summary
+        role="button"
+        slot="summary"
+        tabIndex={0}
+        aria-expanded="false"
+      >
         {renderHeader(conceptExtraction.extractionRecord)}
       </Details.Summary>
       <Details.Content>

--- a/libs/ui-v2/src/lib/import-result-details/index.tsx
+++ b/libs/ui-v2/src/lib/import-result-details/index.tsx
@@ -382,7 +382,7 @@ const ImportResultDetails = ({
                     key={conceptExtraction?.extractionRecord?.internalId}
                   >
                     <Table.Cell style={{ width: "70%" }}>
-                      <Details>
+                      <Details role="group">
                         <ImportRecordAccordionItem
                           key={`result-${conceptExtraction?.extractionRecord?.internalId}`}
                           targetBaseHref={targetBaseHref}


### PR DESCRIPTION
# Summary fixes #1701

- Add `role="group"` to `<Details>` components
- Add `role="button"`, `slot="summary"`, `tabIndex`, and `aria-expanded` to `<Details.Summary>` components
- Prevents React hydration mismatch where `u-details`/`u-summary` `connectedCallback()` injects attributes before React hydration