### PR TITLE
fix: restore button font-weight to regular (400)

### DIFF
--- a/libs/ui-v2/src/lib/layout/global.css
+++ b/libs/ui-v2/src/lib/layout/global.css
@@ -84,3 +84,7 @@ hr {
   height: 1px;
   background: var(--ds-color-neutral-border-subtle);
 }
+
+.ds-button {
+  font-weight: var(--ds-font-weight-regular);
+}


### PR DESCRIPTION
# Summary fixes #1703

- Override `.ds-button` font-weight to `--ds-font-weight-regular` (400) in `global.css`
- Fixes regression from designsystemet v1.11.1, which changed buttons to `--ds-font-weight-medium` (500)