### PR TITLE
fix: draft status tag warning color

### DIFF
--- a/libs/ui-v2/src/lib/tag/concept-status/ConceptStatus.tsx
+++ b/libs/ui-v2/src/lib/tag/concept-status/ConceptStatus.tsx
@@ -5,7 +5,7 @@ import {
 import { forwardRef } from "react";
 
 enum ConceptStatusColors {
-  DRAFT = "second",
+  DRAFT = "warning",
   CANDIDATE = "info",
   WAITING = "neutral",
   CURRENT = "success",


### PR DESCRIPTION
# Summary fixes #1705

- Change DRAFT concept status tag color from `second` to `warning`