### PR TITLE
fix: restore cursor pointer on form layout links

### DIFF
--- a/libs/ui-v2/src/lib/form-layout/form-layout.module.scss
+++ b/libs/ui-v2/src/lib/form-layout/form-layout.module.scss
@@ -84,6 +84,7 @@
       text-decoration: none;
       font-size: medium;
       width: 100%;
+      cursor: pointer;
 
       &:visited {
         color: inherit;


### PR DESCRIPTION
# Summary fixes #1708

- Add `cursor: pointer` to `.ds-link` in `form-layout.module.scss`
- Restores pointer cursor on side menu link items lost after designsystemet v1.11.1 migration