### PR TITLE
reintroduce combobox input wrapping

### DIFF
--- a/libs/ui-v2/src/lib/layout/global.css
+++ b/libs/ui-v2/src/lib/layout/global.css
@@ -88,3 +88,11 @@ hr {
 .ds-button {
   font-weight: var(--ds-font-weight-regular);
 }
+
+/*
+ * Override width: 100% to let input wrap in flex container
+ * Introduced in https://github.com/digdir/designsystemet/pull/2570
+ */
+.ds-combobox__input {
+  width: auto;
+}


### PR DESCRIPTION
Reintroduserer combobox wrapping-oppførsel som på main. Dette ble endret av designsystemet da input vokste for bred på liten skjerm: https://github.com/digdir/designsystemet/pull/2570

<img width="955" height="106" alt="Screenshot 2026-02-18 at 14 42 54" src="https://github.com/user-attachments/assets/5c339845-6e8a-429a-9637-4f2b4b89e0b2" />
