### PR TITLE
fix: details page heading font-size rendered correctly

### DIFF
--- a/libs/ui-v2/src/lib/details-page-layout/details-page.module.css
+++ b/libs/ui-v2/src/lib/details-page-layout/details-page.module.css
@@ -40,7 +40,12 @@
 
 .headingTitle {
   display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
+  align-items: center;
+  gap: 1.5rem;
   margin-bottom: 1rem;
+}
+
+.heading {
+  padding-bottom: var(--ds-size-4);
+  padding-top: var(--ds-size-8);
 }

--- a/libs/ui-v2/src/lib/details-page-layout/index.tsx
+++ b/libs/ui-v2/src/lib/details-page-layout/index.tsx
@@ -49,7 +49,7 @@ const DetailsPageLayout = ({
     <div className="container">
       <div className={styles.heading}>
         <div className={styles.headingTitle}>
-          <Heading level={2} data-size="lg">
+          <Heading level={2} data-size="md">
             {headingTitle}
           </Heading>
           <span>{headingTag}</span>

--- a/libs/ui-v2/src/lib/layout/global.css
+++ b/libs/ui-v2/src/lib/layout/global.css
@@ -4,7 +4,6 @@
 @layer reset, ds;
 
 html * {
-  font-size: 16px;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   font-family:


### PR DESCRIPTION
# Summary fixes #1714

- Remove `font-size: 16px` from unlayered `html *` rule in `global.css` — it took precedence over all designsystemet components due to CSS layer cascade
- Change `Heading` `data-size` from `lg` to `md` in details page layout
- Adjust heading padding and title alignment in details page layout

### Før
<img width="720" height="267" alt="Skjermbilde 2026-02-19 083950" src="https://github.com/user-attachments/assets/429a1344-594f-4f0c-9e55-959a4981ab11" />

### Etter 
<img width="734" height="236" alt="Skjermbilde 2026-02-19 083958" src="https://github.com/user-attachments/assets/7fc1b540-3b5b-45b1-943d-56258c8e26be" />
