### PR TITLE
refactor: remove Dialog.Block from ConfirmModal

### DIFF
--- a/libs/ui-v2/src/lib/confirm-modal/confirm-modal.module.scss
+++ b/libs/ui-v2/src/lib/confirm-modal/confirm-modal.module.scss
@@ -1,3 +1,11 @@
 .content strong {
   font-weight: 700;
 }
+
+.heading {
+  margin-bottom: var(--ds-size-4);
+}
+
+.content {
+  margin-bottom: var(--ds-size-4);
+}

--- a/libs/ui-v2/src/lib/confirm-modal/index.tsx
+++ b/libs/ui-v2/src/lib/confirm-modal/index.tsx
@@ -1,7 +1,12 @@
 "use client";
 
 import { ReactNode, useEffect, useRef } from "react";
-import { Button, Dialog } from "@digdir/designsystemet-react";
+import {
+  Button,
+  Dialog,
+  Heading,
+  Paragraph,
+} from "@digdir/designsystemet-react";
 import { localization } from "@catalog-frontend/utils";
 import style from "./confirm-modal.module.scss";
 import { DialogActions } from "@catalog-frontend/ui-v2";
@@ -51,20 +56,22 @@ export const ConfirmModal = ({
 
   return (
     <Dialog ref={modalRef}>
-      <Dialog.Block>{title}</Dialog.Block>
-      <Dialog.Block className={style.content}>{content}</Dialog.Block>
-      <Dialog.Block>
-        <DialogActions>
-          <Button data-size="sm" onClick={handleSuccess}>
-            {successButtonText ?? localization.button.success}
+      <Heading className={style.heading} data-size="2xs">
+        {title}
+      </Heading>
+      <Paragraph data-size="sm" className={style.content}>
+        {content}
+      </Paragraph>
+      <DialogActions>
+        <Button data-size="sm" onClick={handleSuccess}>
+          {successButtonText ?? localization.button.success}
+        </Button>
+        {!hideCancel && (
+          <Button data-size="sm" variant="secondary" onClick={handleCancel}>
+            {cancelButtonText ?? localization.button.cancel}
           </Button>
-          {!hideCancel && (
-            <Button data-size="sm" variant="secondary" onClick={handleCancel}>
-              {cancelButtonText ?? localization.button.cancel}
-            </Button>
-          )}
-        </DialogActions>
-      </Dialog.Block>
+        )}
+      </DialogActions>
     </Dialog>
   );
 };


### PR DESCRIPTION
# Summary fixes #1717

- Replace `Dialog.Block` wrappers with `Heading` and `Paragraph` from Designsystemet
- Place `DialogActions` directly inside `<Dialog>` without wrapper
- Add spacing via CSS module classes using `--ds-size-4` token

### Etter
<img width="652" height="182" alt="Skjermbilde 2026-02-19 092317" src="https://github.com/user-attachments/assets/02f18171-018e-4aac-97e0-420d09c88497" />
