### PR TITLE
fix: sync CheckboxGroupFilter internal state when changed externally

### DIFF
--- a/libs/ui-v2/src/lib/checkbox-group-filter/index.tsx
+++ b/libs/ui-v2/src/lib/checkbox-group-filter/index.tsx
@@ -1,3 +1,6 @@
+"use client";
+
+import { useEffect } from "react";
 import {
   Checkbox,
   Fieldset,
@@ -18,9 +21,14 @@ interface Props<T extends string> {
 export const CheckboxGroupFilter = <T extends string>({
   items,
   onChange,
-  value,
+  value = [],
 }: Props<T>) => {
-  const { getCheckboxProps } = useCheckboxGroup({ onChange, value });
+  const { getCheckboxProps, setValue } = useCheckboxGroup({ onChange, value });
+
+  useEffect(() => {
+    setValue(value);
+  }, [value, setValue]);
+
   return (
     <Fieldset>
       {items.map(({ value, label }) => (


### PR DESCRIPTION
Uten dette blir ikke filterene oppdatert når du fjerner via chips:

<img width="452" height="382" alt="Screenshot 2026-02-19 at 12 25 22" src="https://github.com/user-attachments/assets/840620c6-669b-441a-bf68-65894b765dfd" />


<img width="391" height="275" alt="Screenshot 2026-02-19 at 12 25 30" src="https://github.com/user-attachments/assets/c4304a8a-2b8b-49e6-9c73-4376089bc4a9" />


Regner med at det er greit at jeg legger til `use client` og `useEffect`?