### PR TITLE
style: add gap to multivalue textfield tags

### DIFF
--- a/libs/ui-v2/src/lib/formik-multivalue-textfield/formik-multivalue-textfield.module.scss
+++ b/libs/ui-v2/src/lib/formik-multivalue-textfield/formik-multivalue-textfield.module.scss
@@ -22,4 +22,5 @@
   display: flex;
   flex-wrap: wrap;
   margin-top: var(--ds-size-2);
+  gap: var(--ds-size-2);
 }


### PR DESCRIPTION
# Summary fixes #1724

- Legger til `gap: var(--ds-size-2)` mellom tagger i multivalue-tekstfeltet

<img width="374" height="309" alt="Skjermbilde 2026-02-19 144305" src="https://github.com/user-attachments/assets/d16207a5-19e1-4b3a-b804-c7bb1f1efc2a" />