### PR TITLE
fix: replace Paragraph with div in ConfirmModal to prevent nested p hydration error

### DIFF
--- a/libs/ui-v2/src/lib/confirm-modal/index.tsx
+++ b/libs/ui-v2/src/lib/confirm-modal/index.tsx
@@ -1,12 +1,7 @@
 "use client";
 
 import { ReactNode, useEffect, useRef } from "react";
-import {
-  Button,
-  Dialog,
-  Heading,
-  Paragraph,
-} from "@digdir/designsystemet-react";
+import { Button, Dialog, Heading } from "@digdir/designsystemet-react";
 import { localization } from "@catalog-frontend/utils";
 import style from "./confirm-modal.module.scss";
 import { DialogActions } from "@catalog-frontend/ui-v2";
@@ -59,9 +54,7 @@ export const ConfirmModal = ({
       <Heading className={style.heading} data-size="2xs">
         {title}
       </Heading>
-      <Paragraph data-size="sm" className={style.content}>
-        {content}
-      </Paragraph>
+      <div className={style.content}>{content}</div>
       <DialogActions>
         <Button data-size="sm" onClick={handleSuccess}>
           {successButtonText ?? localization.button.success}


### PR DESCRIPTION
# Summary

- Replace `<Paragraph>` with `<div>` in `ConfirmModal` (ui-v2) to prevent invalid nested `<p>` elements
- `<Paragraph>` renders a `<p>` tag, which caused a hydration error when `content` contained `<MarkdownComponent>` (also rendering `<p>` tags)
- The `.content` CSS class is preserved, so spacing is unchanged