### PR TITLE
fix: disable auto-select when input matches display value in combobox

### DIFF
--- a/libs/ui-v2/src/lib/concept-combobox/index.tsx
+++ b/libs/ui-v2/src/lib/concept-combobox/index.tsx
@@ -20,6 +20,9 @@ interface Props<T extends string> {
   searchEnv: string;
 }
 
+// Zero-width space to prevent auto-selection when input matches label exactly
+const INVISIBLE_CHARACTER = "\u200B";
+
 export const ConceptCombobox = <T extends string>(props: Props<T>) => {
   const { fieldLabel, searchEnv } = props;
   const [searchQuery, setSearchQuery] = useState("");
@@ -82,7 +85,8 @@ export const ConceptCombobox = <T extends string>(props: Props<T>) => {
           key={option.uri}
           displayValue={
             option.title
-              ? capitalizeFirstLetter(getTranslateText(option.title))
+              ? INVISIBLE_CHARACTER +
+                capitalizeFirstLetter(getTranslateText(option.title))
               : option.uri
           }
         >

--- a/libs/ui-v2/src/lib/formik-reference-data-combobox/index.tsx
+++ b/libs/ui-v2/src/lib/formik-reference-data-combobox/index.tsx
@@ -13,6 +13,9 @@ interface Props extends ComboboxProps {
   ref?: Ref<HTMLInputElement>;
 }
 
+// Zero-width space to prevent auto-selection when input matches label exactly
+const INVISIBLE_CHARACTER = "\u200B";
+
 export function FormikReferenceDataCombobox({
   formikValues,
   selectedValuesSearchHits,
@@ -58,6 +61,7 @@ export function FormikReferenceDataCombobox({
           value={item.uri}
           description={showCodeAsDescription ? item?.code : ""}
         >
+          {INVISIBLE_CHARACTER}
           {item.label ? getTranslateText(item.label) : item.uri}
         </Combobox.Option>
       ))}

--- a/libs/ui-v2/src/lib/spatial-combobox/index.tsx
+++ b/libs/ui-v2/src/lib/spatial-combobox/index.tsx
@@ -15,6 +15,9 @@ interface Props {
   referenceDataEnv: string;
 }
 
+// Zero-width space to prevent auto-selection when input matches label exactly
+const INVISIBLE_CHARACTER = "\u200B";
+
 export const SpatialCombobox = ({ referenceDataEnv }: Props) => {
   const [searchTerm, setSearchTerm] = useState<string>("");
   const debouncedSearchTerm = useDebounce(searchTerm);
@@ -78,6 +81,7 @@ export const SpatialCombobox = ({ referenceDataEnv }: Props) => {
           value={item.uri}
           description={getDescription(item)}
         >
+          {INVISIBLE_CHARACTER}
           {item.label ? getTranslateText(item.label) : item.uri}
         </Combobox.Option>
       ))}


### PR DESCRIPTION
Er en litt snodig oppførsel i combobox etter oppgradering, hvis input er eksakt match med et valg så blir det automatisk valgt.

Dvs hvis jeg vil legge til formatet JSON så legger den til JS når jeg begynner å skrive, først da kan jeg skrive inn og velge JSON

Hvis jeg vil legge til Åsnes som spatial så legger den til Ås når jeg begynner å skrive, etter det kan jeg søke og legge til Åsnes

osv

Etter som jeg kan se så er dette innebygd oppførsel i nåværende versjon av combobox, så legger i stedet til en litt shitty hack for å komme rundt det. Karakteren u200B er en whitespace uten bredde, så vil ikke være synlig, men den vil også stoppe combobox fra å matche display value med input.