### PR TITLE
style: remove icon from validation message

### DIFF
--- a/libs/ui-v2/src/lib/layout/global.css
+++ b/libs/ui-v2/src/lib/layout/global.css
@@ -95,3 +95,12 @@ hr {
 .ds-combobox__input {
   width: auto;
 }
+
+/* Remove validation icon from ValidationMessage, keep only text */
+.ds-validation-message::before {
+  display: none;
+}
+
+.ds-validation-message {
+  padding-inline-start: 0;
+}


### PR DESCRIPTION
# Summary

- Hides the icon in `ValidationMessage` by setting `::before` pseudo-element to `display: none`
- Removes left padding from `ValidationMessage` since icon is no longer shown