### PR TITLE
fix: mismatching field headers

### DIFF
--- a/libs/ui-v2/src/lib/title-with-help-text-and-tag/index.tsx
+++ b/libs/ui-v2/src/lib/title-with-help-text-and-tag/index.tsx
@@ -1,4 +1,4 @@
-import { Tag } from "@digdir/designsystemet-react";
+import { Label, Tag } from "@digdir/designsystemet-react";
 import { localization } from "@catalog-frontend/utils";
 import styles from "./label.module.css";
 import { HelpMarkdown } from "../help-markdown";
@@ -34,7 +34,7 @@ export function TitleWithHelpTextAndTag({
 }: Props) {
   return (
     <div className={styles.container}>
-      {title}
+      <Label data-size="sm">{title}</Label>
       {helpText && (
         <HelpMarkdown aria-label={`${localization.helpWithCompleting}`}>
           {helpText}


### PR DESCRIPTION
Fixes issue with mismatching labels for form components. Ex.: 
<img width="958" height="321" alt="bilde" src="https://github.com/user-attachments/assets/9b90cc0b-82a0-4c9f-9f32-fe50b9460878" />
