### PR TITLE
use designsystemet breadcrumbs

### DIFF
--- a/libs/ui-v2/src/lib/breadcrumbs/breadcrumbs.module.css
+++ b/libs/ui-v2/src/lib/breadcrumbs/breadcrumbs.module.css
@@ -1,35 +1,8 @@
 .breadcrumbs {
-  color: #335380;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  margin: 1.6rem auto;
-  overflow-wrap: break-word;
+  margin-top: var(--ds-size-8);
+  margin-bottom: var(--ds-size-8);
 }
 
-.link {
-  text-decoration: none;
-  border-bottom: solid 1px;
-  padding-bottom: 0.5px;
-  font-style: normal;
-  font-weight: 400;
-  line-height: 2.4rem;
-  color: #1e2b3c;
-}
-
-.link:hover {
-  border-bottom: none;
-}
-
-.deactiveLink {
-  font-style: normal;
-  font-weight: 400;
-  line-height: 2.4rem;
-  color: #1e2b3c;
-}
-
-.separator {
-  height: 0.8rem;
-  width: 0.4rem;
-  margin: 0 1rem 0 1rem;
+.breadcrumbLink {
+  color: inherit; /* override default ds-link color */
 }

--- a/libs/ui-v2/src/lib/breadcrumbs/index.tsx
+++ b/libs/ui-v2/src/lib/breadcrumbs/index.tsx
@@ -1,49 +1,57 @@
-import { hashCode, localization } from "@catalog-frontend/utils";
+import { localization } from "@catalog-frontend/utils";
+import {
+  Breadcrumbs as DSBreadcrumbs,
+  BreadcrumbsList,
+  BreadcrumbsItem,
+  BreadcrumbsLink,
+} from "@digdir/designsystemet-react";
+import classNames from "classnames";
 import styles from "./breadcrumbs.module.css";
-import Link from "next/link";
+
 export type BreadcrumbType = {
   href: string;
   text: string;
 };
 
-export interface BreadcrumbsProps {
+interface Props {
   breadcrumbList?: BreadcrumbType[];
   catalogPortalUrl: string;
 }
 
-const Breadcrumbs = ({
-  breadcrumbList,
-  catalogPortalUrl,
-}: BreadcrumbsProps) => {
+export const Breadcrumbs = (props: Props) => {
+  const { breadcrumbList, catalogPortalUrl } = props;
   return (
-    <div className="container">
-      <nav className={styles.breadcrumbs}>
-        <span>
-          <a
-            className={styles.link}
-            aria-label={localization.catalogOverview}
+    <DSBreadcrumbs
+      className={classNames("container", styles.breadcrumbs)}
+      data-size="sm"
+    >
+      <BreadcrumbsLink
+        aria-label={localization.button.backToOverview}
+        className={styles.breadcrumbLink}
+        href={catalogPortalUrl}
+      >
+        {localization.catalogOverview}
+      </BreadcrumbsLink>
+      <BreadcrumbsList>
+        <BreadcrumbsItem>
+          <BreadcrumbsLink
+            className={styles.breadcrumbLink}
             href={catalogPortalUrl}
           >
             {localization.catalogOverview}
-          </a>
-          {breadcrumbList?.map((breadcrumb, i) => {
-            return (
-              <span key={hashCode(breadcrumb.href)}>
-                <span className={styles.separator}>{">"}</span>
-                {i === breadcrumbList.length - 1 ? (
-                  <span className={styles.deactiveLink}>{breadcrumb.text}</span>
-                ) : (
-                  <Link href={breadcrumb.href} className={styles.link}>
-                    {breadcrumb.text}
-                  </Link>
-                )}
-              </span>
-            );
-          })}
-        </span>
-      </nav>
-    </div>
+          </BreadcrumbsLink>
+        </BreadcrumbsItem>
+        {breadcrumbList?.map((breadcrumb) => (
+          <BreadcrumbsItem key={breadcrumb.href}>
+            <BreadcrumbsLink
+              href={breadcrumb.href}
+              className={styles.breadcrumbLink}
+            >
+              {breadcrumb.text}
+            </BreadcrumbsLink>
+          </BreadcrumbsItem>
+        ))}
+      </BreadcrumbsList>
+    </DSBreadcrumbs>
   );
 };
-
-export { Breadcrumbs };


### PR DESCRIPTION
Bruker designsystemets Breadcrumbs komponent i ui-v2

Før/etter:

<img width="790" height="180" alt="bc" src="https://github.com/user-attachments/assets/1d265859-d3af-44c8-a57e-2a6ce67dd5eb" />

Ny feature: blir til tilbake-knapp på mobil (<650px)

<img width="391" height="256" alt="Screenshot 2026-02-23 at 15 50 18" src="https://github.com/user-attachments/assets/0874b7f3-f683-4473-a181-5e9e17c74231" />
