### PR TITLE
fix: checkbox label overridden by getCheckboxProps spread

### DIFF
--- a/libs/ui-v2/src/lib/checkbox-group-filter/index.tsx
+++ b/libs/ui-v2/src/lib/checkbox-group-filter/index.tsx
@@ -35,8 +35,9 @@ export const CheckboxGroupFilter = <T extends string>({
         <Checkbox
           data-size="sm"
           key={value}
-          label={label}
           {...getCheckboxProps({ value })}
+          label={label}
+          title={label}
         />
       ))}
     </Fieldset>


### PR DESCRIPTION
# Summary fixes #1749

- Flytt `label={label}` etter `{...getCheckboxProps({ value })}` så det ikke overskrives av spreaden
- Fikser noen Playwright-tester i blant annet concept-catalog