### PR TITLE
fix: navigation card visuals after designsystemet 1.11.1

### DIFF
--- a/libs/ui-v2/src/lib/import-result-details/index.tsx
+++ b/libs/ui-v2/src/lib/import-result-details/index.tsx
@@ -190,7 +190,7 @@ const ImportResultDetails = ({
       conceptExtraction.conceptExtractionStatus ===
       ConceptExtractionStatus.PENDING_CONFIRMATION
     ) {
-      return "first";
+      return "brand1";
     } else if (
       conceptExtraction.conceptExtractionStatus ===
       ConceptExtractionStatus.SAVING_FAILED
@@ -339,7 +339,7 @@ const ImportResultDetails = ({
             <Button
               variant="secondary"
               data-size="sm"
-              data-color="first"
+              data-color="brand1"
               disabled={
                 saveConceptMutation?.isPending ||
                 importResult?.status === ImportResultStatus.CANCELLED ||

--- a/libs/ui-v2/src/lib/navigation-card/index.tsx
+++ b/libs/ui-v2/src/lib/navigation-card/index.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import styles from "./navigation-card.module.css";
-import { Heading, Card, Paragraph } from "@digdir/designsystemet-react";
+import { Card, Heading, Paragraph } from "@digdir/designsystemet-react";
 interface CardProps {
   title?: string;
   body?: React.ReactElement | string;
@@ -14,7 +14,8 @@ interface CardProps {
 const NavigationCard = ({ title, body, href, icon, subtitle }: CardProps) => {
   return (
     <Card
-      data-color="third"
+      data-color="accent"
+      variant="tinted"
       asChild={Boolean(href)}
       className={styles.cardBase}
     >
@@ -30,7 +31,7 @@ const NavigationCard = ({ title, body, href, icon, subtitle }: CardProps) => {
               {subtitle}
             </Heading>
           )}
-          <Card.Block className={styles.body}>{body}</Card.Block>
+          <Paragraph className={styles.body}>{body}</Paragraph>
         </Link>
       ) : (
         <div className={styles.card}>


### PR DESCRIPTION
# Summary fixes #1754

- Replace invalid `data-color="third"` with `data-color="accent"` on `NavigationCard`
- Add `variant="tinted"` to restore colored card background
- Replace `Card.Block` with `Paragraph` to fix missing padding and unwanted borders
- Replace invalid `data-color="first"` with `data-color="brand1"` in `ImportResultDetails`