### PR TITLE
fix: use updatedByAt in concept activity log

### DIFF
--- a/apps/concept-catalog/app/catalogs/[catalogId]/activity-log/concept-activity-log.tsx
+++ b/apps/concept-catalog/app/catalogs/[catalogId]/activity-log/concept-activity-log.tsx
@@ -37,7 +37,7 @@ export const ConceptActivityLog = ({
             </Heading>
             <p className={styles.text}>
               {localization.formatString(
-                localization.activityLog.createdByAt,
+                localization.activityLog.updatedByAt,
                 convertTimestampToDateAndTime(update.datetime),
                 update.person?.name ?? localization.unknown,
               )}

--- a/libs/utils/src/lib/language/nb.ts
+++ b/libs/utils/src/lib/language/nb.ts
@@ -87,6 +87,7 @@ export const nb = {
     noComments: "Ingen kommentarer",
     selectType: "Velg type",
     createdByAt: "Opprettet: {0} av {1}",
+    updatedByAt: "Oppdatert: {0} av {1}",
   },
   helpText: "Hjelpetekst",
   publisher: "Utgiver",


### PR DESCRIPTION
# Summary fixes #1768

- Add `updatedByAt` localization key with text "Oppdatert: {0} av {1}"
- Use `updatedByAt` instead of `createdByAt` in concept activity log