### PR TITLE
chore: migrate catalog-portal to ui-v2

### DIFF
--- a/apps/catalog-portal/app/auth/layout.tsx
+++ b/apps/catalog-portal/app/auth/layout.tsx
@@ -1,4 +1,4 @@
-import { Layout } from "@catalog-frontend/ui";
+import { Layout } from "@catalog-frontend/ui-v2";
 import { localization } from "@catalog-frontend/utils";
 
 const PageLayout = ({ children }: { children: React.ReactNode }) => {

--- a/apps/catalog-portal/app/no-access/layout.tsx
+++ b/apps/catalog-portal/app/no-access/layout.tsx
@@ -1,4 +1,4 @@
-import { Layout } from "@catalog-frontend/ui";
+import { Layout } from "@catalog-frontend/ui-v2";
 import { localization } from "@catalog-frontend/utils";
 
 const PageLayout = ({ children }: { children: React.ReactNode }) => {

--- a/apps/catalog-portal/app/terms-and-conditions/[catalogId]/layout.tsx
+++ b/apps/catalog-portal/app/terms-and-conditions/[catalogId]/layout.tsx
@@ -1,4 +1,4 @@
-import { Layout } from "@catalog-frontend/ui";
+import { Layout } from "@catalog-frontend/ui-v2";
 import { localization } from "@catalog-frontend/utils";
 
 const PageLayout = async (props: {


### PR DESCRIPTION
# Summary

- Update Layout imports from `@catalog-frontend/ui` to `@catalog-frontend/ui-v2` in auth, no-access, and terms-and-conditions layouts