### PR TITLE
chore: konverter next.config.js til next.config.ts

### DIFF
--- a/apps/catalog-admin/next.config.ts
+++ b/apps/catalog-admin/next.config.ts
@@ -1,9 +1,8 @@
-//@ts-check
-const path = require("path");
-const { withNx } = require("@nx/next/plugins/with-nx");
+import path from "path";
+import type { WithNxOptions } from "@nx/next/plugins/with-nx.js";
+import { withNx } from "@nx/next/plugins/with-nx.js";
 
-/** @type {import('next').NextConfig} */
-const nextConfig = {
+const nextConfig: WithNxOptions = {
   turbopack: {
     root: path.join(__dirname, "../.."),
     rules: {
@@ -18,4 +17,4 @@ const nextConfig = {
   },
 };
 
-module.exports = withNx(nextConfig);
+export default withNx(nextConfig);

--- a/apps/catalog-portal/next.config.ts
+++ b/apps/catalog-portal/next.config.ts
@@ -1,9 +1,8 @@
-//@ts-check
-const path = require("path");
-const { withNx } = require("@nx/next/plugins/with-nx");
+import path from "path";
+import type { WithNxOptions } from "@nx/next/plugins/with-nx.js";
+import { withNx } from "@nx/next/plugins/with-nx.js";
 
-/** @type {import('next').NextConfig} */
-const nextConfig = {
+const nextConfig: WithNxOptions = {
   turbopack: {
     root: path.join(__dirname, "../.."),
     rules: {
@@ -18,4 +17,4 @@ const nextConfig = {
   },
 };
 
-module.exports = withNx(nextConfig);
+export default withNx(nextConfig);

--- a/apps/concept-catalog/next.config.ts
+++ b/apps/concept-catalog/next.config.ts
@@ -1,9 +1,8 @@
-//@ts-check
-const path = require("path");
-const { withNx } = require("@nx/next/plugins/with-nx");
+import path from "path";
+import type { WithNxOptions } from "@nx/next/plugins/with-nx.js";
+import { withNx } from "@nx/next/plugins/with-nx.js";
 
-/** @type {import('next').NextConfig} */
-const nextConfig = {
+const nextConfig: WithNxOptions = {
   experimental: {
     serverActions: {
       bodySizeLimit: "10mb",
@@ -37,4 +36,4 @@ const nextConfig = {
   },
 };
 
-module.exports = withNx(nextConfig);
+export default withNx(nextConfig);

--- a/apps/data-service-catalog/next.config.ts
+++ b/apps/data-service-catalog/next.config.ts
@@ -1,9 +1,8 @@
-//@ts-check
-const path = require("path");
-const { withNx } = require("@nx/next/plugins/with-nx");
+import path from "path";
+import type { WithNxOptions } from "@nx/next/plugins/with-nx.js";
+import { withNx } from "@nx/next/plugins/with-nx.js";
 
-/** @type {import('next').NextConfig} */
-const nextConfig = {
+const nextConfig: WithNxOptions = {
   turbopack: {
     root: path.join(__dirname, "../.."),
     rules: {
@@ -18,4 +17,4 @@ const nextConfig = {
   },
 };
 
-module.exports = withNx(nextConfig);
+export default withNx(nextConfig);

--- a/apps/dataset-catalog/next.config.ts
+++ b/apps/dataset-catalog/next.config.ts
@@ -1,9 +1,8 @@
-//@ts-check
-const path = require("path");
-const { withNx } = require("@nx/next/plugins/with-nx");
+import path from "path";
+import type { WithNxOptions } from "@nx/next/plugins/with-nx.js";
+import { withNx } from "@nx/next/plugins/with-nx.js";
 
-/** @type {import('next').NextConfig} */
-const nextConfig = {
+const nextConfig: WithNxOptions = {
   env: {
     DATASET_CATALOG_BASE_URI: process.env.DATASET_CATALOG_BASE_URI,
   },
@@ -21,4 +20,4 @@ const nextConfig = {
   },
 };
 
-module.exports = withNx(nextConfig);
+export default withNx(nextConfig);

--- a/apps/service-catalog/next.config.ts
+++ b/apps/service-catalog/next.config.ts
@@ -1,9 +1,8 @@
-//@ts-check
-const path = require("path");
-const { withNx } = require("@nx/next/plugins/with-nx");
+import path from "path";
+import type { WithNxOptions } from "@nx/next/plugins/with-nx.js";
+import { withNx } from "@nx/next/plugins/with-nx.js";
 
-/** @type {import('next').NextConfig} */
-const nextConfig = {
+const nextConfig: WithNxOptions = {
   env: {
     SERVICE_CATALOG_BASE_URI: process.env.SERVICE_CATALOG_BASE_URI,
   },
@@ -21,4 +20,4 @@ const nextConfig = {
   },
 };
 
-module.exports = withNx(nextConfig);
+export default withNx(nextConfig);


### PR DESCRIPTION
# Summary fixes #1775

- Konverterer alle 6 next.config.js til next.config.ts
- Erstatter CJS (require/module.exports) med ESM (import/export default)
- Legger til TypeScript-typing med WithNxOptions fra @nx/next