### PR TITLE
fix: guard concept self-filter when conceptId is empty

### DIFF
--- a/apps/concept-catalog/components/concept-form/components/relation-fieldset/index.tsx
+++ b/apps/concept-catalog/components/concept-form/components/relation-fieldset/index.tsx
@@ -162,7 +162,7 @@ export const RelationFieldset = ({
   if (relatedConceptType === "internal" && searchTriggered) {
     internalRelatedConceptOptions =
       internalConcepts?.hits
-        .filter((rel) => rel.originaltBegrep !== conceptId)
+        .filter((rel) => !conceptId || rel.originaltBegrep !== conceptId)
         .map((concept) => ({
           label: getTranslateText(concept.anbefaltTerm?.navn),
           value: concept.originaltBegrep as string,
@@ -183,7 +183,7 @@ export const RelationFieldset = ({
   if (relatedConceptType === "external" && searchTriggered) {
     externalRelatedConceptOptions =
       externalConcepts?.hits
-        .filter((rel) => !rel.uri?.includes(conceptId))
+        .filter((rel) => !conceptId || !rel.uri?.includes(conceptId))
         .map((concept) => ({
           label: getTranslateText(concept.title),
           description: getTranslateText(


### PR DESCRIPTION
# Summary fixes [#1245](https://github.com/Informasjonsforvaltning/fdk-issue-tracker/issues/1245)

- Guard internal concept filter so empty `conceptId` doesn't exclude all results
- Guard external concept filter to prevent `includes("")` from matching every URI