### PR TITLE
fix: deduplicate external concept combobox options

### DIFF
--- a/apps/concept-catalog/components/concept-form/components/relation-fieldset/index.tsx
+++ b/apps/concept-catalog/components/concept-form/components/relation-fieldset/index.tsx
@@ -181,16 +181,25 @@ export const RelationFieldset = ({
   }
 
   if (relatedConceptType === "external" && searchTriggered) {
-    externalRelatedConceptOptions =
+    const mapped =
       externalConcepts?.hits
         .filter((rel) => !conceptId || !rel.uri?.includes(conceptId))
-        .map((concept) => ({
-          label: getTranslateText(concept.title),
-          description: getTranslateText(
-            concept.organization?.prefLabel,
-          ) as string,
-          value: concept.uri as string,
-        })) ?? [];
+        .filter((concept) => Boolean(concept.uri))
+        .map(
+          (concept) =>
+            [
+              concept.uri,
+              {
+                label: getTranslateText(concept.title),
+                description: getTranslateText(
+                  concept.organization?.prefLabel,
+                ) as string,
+                value: concept.uri as string,
+              },
+            ] as const,
+        ) ?? [];
+
+    externalRelatedConceptOptions = [...new Map(mapped).values()];
   } else if (
     relatedConceptType === "external" &&
     !searchTriggered &&


### PR DESCRIPTION
# Summary fixes #1781

- Deduplicate external concept search results by URI using a Map
- Filter out entries with falsy URI before mapping
- Prevents React duplicate key errors and Designsystemet Combobox crash on re-search