### PR TITLE
fix: defer setFieldValue in relation fieldset radio

### DIFF
--- a/apps/concept-catalog/components/concept-form/components/relation-fieldset/index.tsx
+++ b/apps/concept-catalog/components/concept-form/components/relation-fieldset/index.tsx
@@ -216,8 +216,6 @@ export const RelationFieldset = ({
   }
 
   const handleRelatedConceptTypeChange = (value) => {
-    setFieldValue("internal", value === "internal");
-
     setRelatedConceptType(value as RelatedConceptType);
     setRelatedConcept([]);
   };
@@ -266,6 +264,10 @@ export const RelationFieldset = ({
       ? relatedConcept
       : [];
   };
+
+  useEffect(() => {
+    setFieldValue("internal", relatedConceptType === "internal");
+  }, [relatedConceptType]);
 
   useEffect(() => {
     setFieldValue("relatertBegrep", relatedConcept[0]);


### PR DESCRIPTION
# Summary fixes #1785

- Removed `setFieldValue("internal", ...)` from `handleRelatedConceptTypeChange` to avoid state update during render
- Added `useEffect` to sync `relatedConceptType` to Formik, matching existing pattern for `relatedConcept`