### PR TITLE
fix: remove ignoreBuildErrors in catalog-admin

### DIFF
--- a/apps/catalog-admin/app/api/design/[...slug]/route.ts
+++ b/apps/catalog-admin/app/api/design/[...slug]/route.ts
@@ -8,7 +8,7 @@ import { NextRequest } from "next/server";
 
 export const GET = async (
   req: NextRequest,
-  props: { params: Promise<{ slug: string }> },
+  props: { params: Promise<{ slug: string[] }> },
 ) => {
   const params = await props.params;
   return await withValidSessionForApi(async (session) => {
@@ -65,7 +65,7 @@ export const GET = async (
 
 export const PATCH = async (
   req: NextRequest,
-  props: { params: Promise<{ slug: string }> },
+  props: { params: Promise<{ slug: string[] }> },
 ) => {
   const params = await props.params;
   return await withValidSessionForApi(async (session) => {

--- a/apps/catalog-admin/components/color-picker/index.tsx
+++ b/apps/catalog-admin/components/color-picker/index.tsx
@@ -28,9 +28,9 @@ export const ColorPicker = ({ catalogId, type }: ColorPicker) => {
 
   useEffect(() => {
     if (type === "background") {
-      setInputColor(backgroundColor);
+      setInputColor(backgroundColor ?? "");
     } else {
-      setInputColor(fontColor);
+      setInputColor(fontColor ?? "");
     }
   }, []);
 
@@ -54,8 +54,8 @@ export const ColorPicker = ({ catalogId, type }: ColorPicker) => {
       dbDesign?.fontColor !== undefined &&
       type === "background"
     ) {
-      setInputColor(dbDesign?.backgroundColor);
-      setIsValidInput(colorRegex.test(dbDesign?.backgroundColor));
+      setInputColor(dbDesign?.backgroundColor ?? "");
+      setIsValidInput(colorRegex.test(dbDesign?.backgroundColor ?? ""));
     }
 
     if (

--- a/apps/catalog-admin/components/image-uploader/image-uploader.spec.tsx
+++ b/apps/catalog-admin/components/image-uploader/image-uploader.spec.tsx
@@ -11,7 +11,7 @@ describe("ImageUploader", () => {
     const queryClient = new QueryClient();
     const { baseElement } = render(
       <QueryClientProvider client={queryClient}>
-        <ImageUploader />
+        <ImageUploader catalogId="123456789" />
       </QueryClientProvider>,
     );
     expect(baseElement).toBeTruthy();

--- a/apps/catalog-admin/components/user-editor/index.tsx
+++ b/apps/catalog-admin/components/user-editor/index.tsx
@@ -31,12 +31,13 @@ export const UserEditor = ({ catalogId, user, type }: UserEditorProps) => {
 
   const adminDispatch = useAdminDispatch();
 
-  const findUserById = (userId: string) =>
+  const findUserById = (userId: string | undefined) =>
     updatedUserList.find((user) => user?.id === userId);
 
   const handleDeleteUser = (user: AssignedUser) => {
+    if (!user.id) return;
     if (window.confirm(`${localization.alert.deleteUser} ${user?.name}`)) {
-      deleteUser.mutate(user?.id);
+      deleteUser.mutate(user.id);
     }
   };
 
@@ -56,16 +57,22 @@ export const UserEditor = ({ catalogId, user, type }: UserEditorProps) => {
   const [updatedUserList, setUpdatedUserList] = useState<AssignedUser[]>([]);
   const [newUser, setNewUser] = useState<AssignedUser>(newUserTemplate);
 
-  const handleUpdateUser = (userId: string) => {
+  const handleUpdateUser = (userId: string | undefined) => {
+    if (!userId) return;
     const updatedUser = updatedUserList.find((user) => user?.id === userId);
-    const dbUser: AssignedUser = getUsers.users.find(
+    const dbUser: AssignedUser | undefined = getUsers.users.find(
       (user: AssignedUser) => user?.id === userId,
     );
-    const diff = dbUser && updatedUser ? compare(dbUser, updatedUser) : null;
+    if (!dbUser || !updatedUser) {
+      alert(localization.alert.noChanges);
+      return;
+    }
 
-    if (diff) {
+    const diff = compare(dbUser, updatedUser);
+
+    if (diff.length > 0) {
       updateUser
-        .mutateAsync({ beforeUpdateUser: dbUser, updatedUser: updatedUser })
+        .mutateAsync({ beforeUpdateUser: dbUser, updatedUser })
         .then(() => {
           alert(localization.alert.success);
         })
@@ -78,11 +85,12 @@ export const UserEditor = ({ catalogId, user, type }: UserEditorProps) => {
   };
 
   const updateUserState = (
-    userId: string,
+    userId: string | undefined,
     newName?: string,
     newEmail?: string,
     newTelephoneNumber?: string,
   ) => {
+    if (!userId) return;
     const updatedUserListIndex = updatedUserList.findIndex(
       (user) => user?.id === userId,
     );
@@ -126,7 +134,7 @@ export const UserEditor = ({ catalogId, user, type }: UserEditorProps) => {
         <Textfield
           error={
             textRegex.test(
-              (findUserById(user?.id) || user)?.name || newUser.name,
+              (findUserById(user?.id) || user)?.name ?? newUser.name ?? "",
             )
               ? null
               : localization.validation.invalidValue
@@ -148,7 +156,7 @@ export const UserEditor = ({ catalogId, user, type }: UserEditorProps) => {
         <Textfield
           error={
             emailRegex.test(
-              (findUserById(user?.id) || user)?.email || newUser.email,
+              (findUserById(user?.id) || user)?.email ?? newUser.email ?? "",
             )
               ? null
               : localization.validation.invalidValue
@@ -185,7 +193,10 @@ export const UserEditor = ({ catalogId, user, type }: UserEditorProps) => {
             {localization.button.cancel}
           </Button>
         ) : (
-          <Button data-color="danger" onClick={() => handleDeleteUser(user)}>
+          <Button
+            data-color="danger"
+            onClick={() => user && handleDeleteUser(user)}
+          >
             {localization.button.delete}
           </Button>
         )}

--- a/apps/catalog-admin/context/admin/context.tsx
+++ b/apps/catalog-admin/context/admin/context.tsx
@@ -28,8 +28,9 @@ interface StateProviderProps {
 const AdminContextProvider = ({ children }: StateProviderProps) => {
   const [state, dispatch] = useReducer(reducer, DefaultAdminState);
 
-  const value = {
-    state,
+  // Immer's produce makes the state deeply readonly, but consumers need mutable AdminState
+  const value: ContextProps = {
+    state: state as AdminState,
     dispatch,
   };
 

--- a/apps/catalog-admin/context/admin/state.ts
+++ b/apps/catalog-admin/context/admin/state.ts
@@ -11,7 +11,7 @@ export interface AdminState {
   updatedCodes?: Record<string, Code[]>;
 }
 
-export const DefaultAdminState = {
+export const DefaultAdminState: AdminState = {
   backgroundColor: "#FFFFFF",
   fontColor: "#2D3741",
   logo: null,
@@ -19,5 +19,5 @@ export const DefaultAdminState = {
   showUserEditor: false,
   showInternalFieldEditor: false,
   showCodeListEditor: false,
-  updatedCodes: null,
+  updatedCodes: undefined,
 };

--- a/apps/catalog-admin/next.config.js
+++ b/apps/catalog-admin/next.config.js
@@ -13,9 +13,6 @@ const nextConfig = {
       },
     },
   },
-  typescript: {
-    ignoreBuildErrors: true,
-  },
 };
 
 module.exports = withNx(nextConfig);

--- a/libs/data-access/src/lib/concept/api/index.ts
+++ b/libs/data-access/src/lib/concept/api/index.ts
@@ -248,7 +248,7 @@ export const getPublishedRelatedConcepts = async (
 ): Promise<RelatedConcept[]> => {
   if (!hasRelatedConcepts(concept)) return [];
 
-  const relatedConceptsUris = [];
+  const relatedConceptsUris: (string | undefined)[] = [];
 
   if (concept.begrepsRelasjon)
     relatedConceptsUris.push(

--- a/libs/ui/src/lib/auth-session-modal/index.tsx
+++ b/libs/ui/src/lib/auth-session-modal/index.tsx
@@ -39,7 +39,7 @@ export const AuthSessionModal = ({
   };
 
   const handleLoginClick = () => {
-    if (pathName.includes(signInPath)) {
+    if (pathName?.includes(signInPath)) {
       return (window.location.href = signInPath);
     } else {
       return router.push(`${signInPath}?callbackUrl=${window.location.href}`);

--- a/libs/ui/src/lib/header/index.tsx
+++ b/libs/ui/src/lib/header/index.tsx
@@ -93,7 +93,8 @@ const Header: FC<HeaderProps> = ({
     ],
   ];
 
-  const { catalogId } = useParams();
+  const params = useParams();
+  const catalogId = params?.catalogId;
   const { data: session } = useSession();
   const userDisplayName = session?.user?.name;
   const accessToken = (session as any)?.accessToken;

--- a/libs/ui/src/lib/intersection-observer/index.tsx
+++ b/libs/ui/src/lib/intersection-observer/index.tsx
@@ -46,7 +46,7 @@ export const useIntersectionObserver = ({
     const observer = new IntersectionObserver(
       (entries) => {
         let activeSectionIntersecting = false;
-        let sectionToActive = null;
+        let sectionToActive: string | null = null;
         entries.forEach((entry) => {
           if (entry.isIntersecting && activeSection === entry.target.id) {
             activeSectionIntersecting = true;

--- a/libs/ui/src/lib/keycloak-signin/index.tsx
+++ b/libs/ui/src/lib/keycloak-signin/index.tsx
@@ -9,14 +9,14 @@ import { useEffect } from "react";
 const KeycloakSignin = () => {
   const pathName = usePathname();
   const searchParams = useSearchParams();
-  const callbackUrl = searchParams.get("callbackUrl");
+  const callbackUrl = searchParams?.get("callbackUrl");
 
   useEffect(() => {
     signIn(
       "keycloak",
       callbackUrl
         ? { callbackUrl }
-        : { callbackUrl: pathName.includes("auth") ? "/" : undefined },
+        : { callbackUrl: pathName?.includes("auth") ? "/" : undefined },
     );
   }, []);
 


### PR DESCRIPTION
# Summary fixes #1810

- Remove `typescript: { ignoreBuildErrors: true }` from `apps/catalog-admin/next.config.js`
- Fix DefaultAdminState type annotation and change `updatedCodes: null` to `undefined`
- Fix immer readonly state mismatch in AdminContext provider
- Add `?? ""` fallbacks for optional string props in ColorPicker
- Widen UserEditor parameter types and add null guards for optional `user` prop
- Fix catch-all route slug type from `string` to `string[]` in design API route
- Add missing `catalogId` prop in ImageUploader test
- Fix shared lib errors in `data-access`, `ui` (auth-session-modal, header, intersection-observer, keycloak-signin)