### PR TITLE
fix: remove ignoreBuildErrors in service-catalog

### DIFF
--- a/apps/service-catalog/app/api/catalogs/[catalogId]/public-services/[serviceId]/route.ts
+++ b/apps/service-catalog/app/api/catalogs/[catalogId]/public-services/[serviceId]/route.ts
@@ -2,7 +2,10 @@ import { deletePublicService } from "@catalog-frontend/data-access";
 import { withValidSessionForApi } from "@catalog-frontend/utils";
 import { NextRequest } from "next/server";
 
-export const DELETE = async (req: NextRequest, props: { params: any }) => {
+export const DELETE = async (
+  _: NextRequest,
+  props: { params: Promise<{ catalogId: string; serviceId: string }> },
+) => {
   const params = await props.params;
   return withValidSessionForApi(async (session) => {
     const { catalogId, serviceId } = params;

--- a/apps/service-catalog/app/api/catalogs/[catalogId]/services/[serviceId]/route.ts
+++ b/apps/service-catalog/app/api/catalogs/[catalogId]/services/[serviceId]/route.ts
@@ -2,7 +2,10 @@ import { deleteService } from "@catalog-frontend/data-access";
 import { withValidSessionForApi } from "@catalog-frontend/utils";
 import { NextRequest } from "next/server";
 
-export const DELETE = async (req: NextRequest, props: { params: any }) => {
+export const DELETE = async (
+  _: NextRequest,
+  props: { params: Promise<{ catalogId: string; serviceId: string }> },
+) => {
   const params = await props.params;
   return withValidSessionForApi(async (session) => {
     const { catalogId, serviceId } = params;

--- a/apps/service-catalog/next.config.js
+++ b/apps/service-catalog/next.config.js
@@ -16,9 +16,6 @@ const nextConfig = {
       },
     },
   },
-  typescript: {
-    ignoreBuildErrors: true,
-  },
 };
 
 module.exports = withNx(nextConfig);


### PR DESCRIPTION
# Summary fixes #1806

- Remove `ignoreBuildErrors: true` from `apps/service-catalog/next.config.js`
- Fix `params: any` to proper `Promise<{ catalogId: string; serviceId: string }>` type in DELETE route handlers for services and public-services