### PR TITLE
fix: remove ignoreBuildErrors in dataset-catalog

### DIFF
--- a/apps/dataset-catalog/app/catalogs/[catalogId]/datasets/datasets-page-client.tsx
+++ b/apps/dataset-catalog/app/catalogs/[catalogId]/datasets/datasets-page-client.tsx
@@ -256,7 +256,11 @@ const DatasetsPageClient = ({
                 removeFilter(filter, "status");
               }}
             >
-              {localization.datasetForm.filter[filter]}
+              {
+                localization.datasetForm.filter[
+                  filter as keyof typeof localization.datasetForm.filter
+                ]
+              }
             </Chip.Removable>
           ))}
           {filterPublicationState?.map((filter, index) => (

--- a/apps/dataset-catalog/components/dataset-form/components/distribution-section/distribution-modal.tsx
+++ b/apps/dataset-catalog/components/dataset-form/components/distribution-section/distribution-modal.tsx
@@ -35,7 +35,7 @@ import {
   Skeleton,
   Textfield,
 } from "@digdir/designsystemet-react";
-import { FastField, FieldArray, Formik } from "formik";
+import { FastField, FieldArray, Formik, getIn } from "formik";
 import styles from "./distributions.module.scss";
 import { distributionTemplate } from "../../utils/dataset-initial-values";
 import {
@@ -917,7 +917,7 @@ export const DistributionModal = ({
                               }}
                               data-size="sm"
                               virtual
-                              error={errors?.rights?.type}
+                              error={getIn(errors, "rights.type")}
                             >
                               <Combobox.Option key="right.type" value="">
                                 {localization.none}

--- a/apps/dataset-catalog/components/dataset-form/components/toggle-field-button.tsx
+++ b/apps/dataset-catalog/components/dataset-form/components/toggle-field-button.tsx
@@ -57,7 +57,7 @@ export const ToggleFieldButton = ({
             setFieldValue(fieldName, addValue);
             setFocus && setFocus(fieldName);
           }}
-        >{`${localization.add} ${localization.datasetForm.fieldLabel[fieldName.split(".")[0]]?.toLowerCase()}`}</AddButton>
+        >{`${localization.add} ${localization.datasetForm.fieldLabel[fieldName.split(".")[0] as keyof typeof localization.datasetForm.fieldLabel]?.toLowerCase()}`}</AddButton>
       )}
     </div>
   );

--- a/apps/dataset-catalog/components/details-page-columns/components/access-rights-details.tsx
+++ b/apps/dataset-catalog/components/details-page-columns/components/access-rights-details.tsx
@@ -107,7 +107,11 @@ export const AccessRightsDetails = ({ dataset, language }: Props) => {
                             </Link>
                           </Table.Cell>
                           <Table.Cell>
-                            {localization.datasetForm.fieldLabel[item?.type]}
+                            {
+                              localization.datasetForm.fieldLabel[
+                                item?.type as keyof typeof localization.datasetForm.fieldLabel
+                              ]
+                            }
                           </Table.Cell>
                         </Table.Row>
                       ),

--- a/apps/dataset-catalog/next.config.js
+++ b/apps/dataset-catalog/next.config.js
@@ -16,9 +16,6 @@ const nextConfig = {
       },
     },
   },
-  typescript: {
-    ignoreBuildErrors: true,
-  },
 };
 
 module.exports = withNx(nextConfig);


### PR DESCRIPTION
# Summary fixes #1807

- Remove `typescript: { ignoreBuildErrors: true }` from `next.config.js`
- Fix TS7053: cast string keys with `as keyof typeof` for localization lookups in `datasets-page-client.tsx`, `toggle-field-button.tsx`, and `access-rights-details.tsx`
- Fix TS2339: use Formik's `getIn(errors, 'rights.type')` to access nested error for optional object field in `distribution-modal.tsx`