### PR TITLE
fix: bump axios resolution to patch critical CVEs

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "typescript-eslint": "^8.58.1"
   },
   "resolutions": {
-    "axios": "^1.14.0",
+    "axios": "^1.15.0",
     "lodash": "^4.18.1",
     "lodash-es": "^4.18.1",
     "svgo": "^3.3.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7731,14 +7731,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:^1.14.0":
-  version: 1.14.0
-  resolution: "axios@npm:1.14.0"
+"axios@npm:^1.15.0":
+  version: 1.15.0
+  resolution: "axios@npm:1.15.0"
   dependencies:
     follow-redirects: "npm:^1.15.11"
     form-data: "npm:^4.0.5"
     proxy-from-env: "npm:^2.1.0"
-  checksum: 10/c3444e9e3da1714916e4ddd7cda05bb41a5d5d80e3e27b099a116439684c63f2280c88503d1acd65841698b63af0b542b4d5780454e28fd0aed2d783ef90943e
+  checksum: 10/d39a2c0ebc7ff4739401b282e726cc2673377949d6c46d60eb619458f8d7a2f7eadbcada7097f4dbc7d5c59abb4d3bf6fac33d474412bc3415d3f5aa7ed45530
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Summary

- Bump axios resolution from ^1.14.0 to ^1.15.0 to force the patched version across all transitive dependencies (including nx)
- Fixes GHSA-3p68-rc4w-qgx5 (SSRF via NO_PROXY bypass) and GHSA-fvcv-3m26-pcqx (cloud metadata exfiltration)