### PR TITLE
test: fix flaky dataset-catalog e2e tests

### DIFF
--- a/apps/dataset-catalog-e2e/src/page-object-model/datasetDetailPage.ts
+++ b/apps/dataset-catalog-e2e/src/page-object-model/datasetDetailPage.ts
@@ -82,6 +82,7 @@ export default class DatasetDetailPage {
 
   async confirmDelete() {
     await this.page.getByRole("button", { name: "Slett", exact: true }).click();
+    await this.page.getByRole("dialog").waitFor({ state: "hidden" });
   }
 
   async cancelDelete() {

--- a/apps/dataset-catalog-e2e/src/page-object-model/datasetEditPage.ts
+++ b/apps/dataset-catalog-e2e/src/page-object-model/datasetEditPage.ts
@@ -882,6 +882,7 @@ export default class DatasetEditPage {
     await option.waitFor({ state: "visible", timeout: 5000 });
     await option.click();
     await dialog.getByRole("button", { name: "Legg til" }).click();
+    await dialog.waitFor({ state: "hidden", timeout: 5000 });
   }
 
   async fillRelatedResourceForm(data: {
@@ -898,6 +899,7 @@ export default class DatasetEditPage {
     );
     await dialog.getByLabel("Lenke").fill(data.uri);
     await dialog.getByRole("button", { name: "Legg til" }).click();
+    await dialog.waitFor({ state: "hidden", timeout: 5000 });
   }
 
   // Concept section
@@ -1015,9 +1017,13 @@ export default class DatasetEditPage {
   }
 
   async expectNoRestoreDialog() {
+    // Wait for the form to fully load (autosaver checks localStorage on mount)
     await this.page
-      .getByRole("dialog")
-      .waitFor({ state: "hidden", timeout: 5000 });
+      .getByRole("group", { name: /Tittel/ })
+      .first()
+      .waitFor({ state: "visible" });
+    // Assert no restore dialog appeared
+    await expect(this.page.getByRole("dialog")).not.toBeVisible();
   }
 
   async waitForAutoSaveToComplete() {

--- a/apps/dataset-catalog-e2e/src/page-object-model/datasetEditPage.ts
+++ b/apps/dataset-catalog-e2e/src/page-object-model/datasetEditPage.ts
@@ -1017,12 +1017,6 @@ export default class DatasetEditPage {
   }
 
   async expectNoRestoreDialog() {
-    // Wait for the form to fully load (autosaver checks localStorage on mount)
-    await this.page
-      .getByRole("group", { name: /Tittel/ })
-      .first()
-      .waitFor({ state: "visible" });
-    // Assert no restore dialog appeared
     await expect(this.page.getByRole("dialog")).not.toBeVisible();
   }
 

--- a/apps/dataset-catalog-e2e/src/page-object-model/datasetEditPage.ts
+++ b/apps/dataset-catalog-e2e/src/page-object-model/datasetEditPage.ts
@@ -858,9 +858,11 @@ export default class DatasetEditPage {
   }
 
   async clickAddRelatedResource() {
-    await this.page
-      .getByRole("button", { name: "Legg til relaterte ressurser" })
-      .click();
+    const button = this.page.getByRole("button", {
+      name: "Legg til relaterte ressurser",
+    });
+    await button.waitFor({ state: "visible" });
+    await button.click();
   }
 
   async fillRelationForm(data: { relationType: string; dataset: string }) {
@@ -1004,16 +1006,12 @@ export default class DatasetEditPage {
 
   async clickRestoreButton() {
     await this.page.getByRole("button", { name: "Gjenopprett" }).click();
-    await this.page
-      .getByRole("dialog")
-      .waitFor({ state: "hidden", timeout: 5000 });
+    await this.page.getByRole("dialog").waitFor({ state: "hidden" });
   }
 
   async clickDiscardButton() {
     await this.page.getByRole("button", { name: "Forkast" }).click();
-    await this.page
-      .getByRole("dialog")
-      .waitFor({ state: "hidden", timeout: 5000 });
+    await this.page.getByRole("dialog").waitFor({ state: "hidden" });
   }
 
   async expectNoRestoreDialog() {

--- a/apps/dataset-catalog-e2e/src/tests/admin/datasetDetailPage.spec.ts
+++ b/apps/dataset-catalog-e2e/src/tests/admin/datasetDetailPage.spec.ts
@@ -136,8 +136,8 @@ runTestAsAdmin(
     await detailPage.expectDeleteConfirmationDialog(dataset.title.nb as string);
     await detailPage.confirmDelete();
 
-    // Verify we're back on the datasets page
-    await expect(datasetsPage.page).toHaveURL(
+    // Wait for navigation back to the datasets page
+    await datasetsPage.page.waitForURL(
       `/catalogs/${process.env.E2E_CATALOG_ID}/datasets`,
     );
 


### PR DESCRIPTION
# Summary

- Wait for relation/resource dialogs to close before next action in `fillRelationForm()` and `fillRelatedResourceForm()`
- Wait for dialog to hide in `confirmDelete()`, and use `waitForURL` instead of `toHaveURL` for the post-delete navigation assertion
- Fix `expectNoRestoreDialog()` race condition: wait for form title field to be visible before asserting no dialog