### PR TITLE
fix: allow gyldigTom without gyldigFom

### DIFF
--- a/apps/concept-catalog-e2e/src/tests/admin/conceptsEditPage.spec.ts
+++ b/apps/concept-catalog-e2e/src/tests/admin/conceptsEditPage.spec.ts
@@ -622,3 +622,57 @@ runTestAsAdmin(
     ).not.toBeVisible();
   },
 );
+
+runTestAsAdmin(
+  "gyldigTom can be saved without gyldigFom (issue #1812)",
+  async ({ conceptsPage, playwright }) => {
+    const apiRequestContext = await playwright.request.newContext({
+      storageState: adminAuthFile,
+    });
+
+    const id = await createConcept(apiRequestContext, {
+      anbefaltTerm: {
+        navn: { nb: "Test gyldigTom uten gyldigFom", nn: "", en: "" },
+      },
+      definisjon: {
+        tekst: { nb: "Definisjon" },
+        kildebeskrivelse: { forholdTilKilde: "egendefinert", kilde: [] },
+      },
+      merknad: {},
+      tillattTerm: {},
+      frarådetTerm: {},
+      eksempel: {},
+      fagområde: {},
+      fagområdeKoder: [],
+      statusURI:
+        "http://publications.europa.eu/resource/authority/concept-status/DRAFT",
+      assignedUser: "",
+      versjonsnr: { major: 0, minor: 1, patch: 0 },
+      gyldigFom: null,
+      gyldigTom: null,
+    });
+
+    await conceptsPage.editPage.goto(id);
+
+    const saveButton = conceptsPage.page.getByRole("button", { name: "Lagre" });
+    await expect(saveButton).toBeVisible();
+
+    const gyldigFom = conceptsPage.page.getByLabel("Gyldig fra og med");
+    const gyldigTom = conceptsPage.page.getByLabel("Gyldig til og med");
+
+    await expect(gyldigFom).toHaveValue("");
+
+    await gyldigTom.fill("2299-01-01");
+    await gyldigTom.blur();
+
+    await expect(
+      conceptsPage.page.getByText("Dato er ikke gyldig"),
+    ).not.toBeVisible();
+
+    await saveButton.click();
+
+    await expect(
+      conceptsPage.page.getByText("Endringene ble lagret."),
+    ).toBeVisible();
+  },
+);

--- a/apps/concept-catalog/components/concept-form/validation-schema.tsx
+++ b/apps/concept-catalog/components/concept-form/validation-schema.tsx
@@ -346,17 +346,20 @@ export const conceptSchema = ({
           }
 
           const tomDateTime = parseDateTime(value);
-          if (tomDateTime?.isValid) {
-            if (this.parent.gyldigFom === null) {
-              return true;
-            }
-            const fomDateTime = parseDateTime(this.parent.gyldigFom);
-            if (
-              fomDateTime &&
-              tomDateTime.toJSDate() >= fomDateTime?.toJSDate()
-            ) {
-              return true;
-            }
+          if (!tomDateTime?.isValid) {
+            return this.createError({
+              message: localization.conceptForm.validation.date,
+              path: this.path,
+            });
+          }
+
+          const fomDateTime = parseDateTime(this.parent.gyldigFom);
+          if (!fomDateTime?.isValid) {
+            return true;
+          }
+
+          if (tomDateTime.toJSDate() >= fomDateTime.toJSDate()) {
+            return true;
           }
 
           return this.createError({


### PR DESCRIPTION
# Summary fixes #1812

- Fix gyldigTom validation to accept a valid date when gyldigFom is empty (null, undefined, or empty string)
- Add E2E regression test covering the bug scenario