### PR TITLE
fix: assosiativ relation type dropdown locks

### DIFF
--- a/apps/concept-catalog/components/concept-form/components/relation-fieldset/index.tsx
+++ b/apps/concept-catalog/components/concept-form/components/relation-fieldset/index.tsx
@@ -123,17 +123,10 @@ export const RelationFieldset = ({
       enabled: Boolean(search),
     });
 
-  const relationTypeOptions = relationTypes
-    .map((item) => ({
-      label: localization.conceptForm.fieldLabel.relationTypes[item],
-      value: item,
-    }))
-    .filter((item) => {
-      if (values.relasjon === RelationTypeEnum.ASSOSIATIV) {
-        return item.value !== RelationTypeEnum.ASSOSIATIV;
-      }
-      return true;
-    });
+  const relationTypeOptions = relationTypes.map((item) => ({
+    label: localization.conceptForm.fieldLabel.relationTypes[item],
+    value: item,
+  }));
 
   const relationSubtypeOptions = relationSubtypes
     .filter((subtype) => {


### PR DESCRIPTION
# Summary fixes #1817

- Remove filter in `relation-fieldset` that stripped "Assosiativ" from the relation type options when it was the current selection, causing the dropdown to appear locked and empty after selecting it