### PR TITLE
fix: temporal date input, validation, and format handling

### DIFF
--- a/apps/dataset-catalog-e2e/src/page-object-model/datasetDetailPage.ts
+++ b/apps/dataset-catalog-e2e/src/page-object-model/datasetDetailPage.ts
@@ -186,8 +186,12 @@ export default class DatasetDetailPage {
   }
 
   async expectPeriod(from: string, to: string) {
-    await expect(this.page.getByText(from)).toBeVisible();
-    await expect(this.page.getByText(to)).toBeVisible();
+    await expect(
+      this.page.getByRole("cell", { name: from, exact: true }),
+    ).toBeVisible();
+    await expect(
+      this.page.getByRole("cell", { name: to, exact: true }),
+    ).toBeVisible();
   }
 
   async expectDatasetType(type: string) {

--- a/apps/dataset-catalog-e2e/src/page-object-model/datasetEditPage.ts
+++ b/apps/dataset-catalog-e2e/src/page-object-model/datasetEditPage.ts
@@ -802,10 +802,10 @@ export default class DatasetEditPage {
       .getByRole("button", { name: "Legg til tidsperiode" })
       .click();
     const dialog = this.page.getByRole("dialog");
-    const fromDateField = dialog.getByLabel("Fra");
+    const fromDateField = dialog.getByLabel("Fra", { exact: true });
     await expect(fromDateField).toBeVisible();
     await fromDateField.fill(from as string);
-    const toDateField = dialog.getByLabel("Til");
+    const toDateField = dialog.getByLabel("Til", { exact: true });
     await expect(toDateField).toBeVisible();
     await toDateField.fill(to as string);
     await dialog.getByRole("button", { name: "Legg til" }).click();

--- a/apps/dataset-catalog-e2e/src/tests/admin/datasetEditPage.spec.ts
+++ b/apps/dataset-catalog-e2e/src/tests/admin/datasetEditPage.spec.ts
@@ -403,6 +403,45 @@ runTestAsAdmin(
 );
 
 runTestAsAdmin(
+  "should trim whitespace from pasted temporal dates",
+  async ({ datasetsPage, playwright, page }) => {
+    const dataset = await createRandomDataset(playwright);
+    const detailPage: DatasetDetailPage = datasetsPage.detailPage;
+    const editPage: DatasetEditPage = datasetsPage.editPage;
+
+    await detailPage.goto(process.env.E2E_CATALOG_ID as string, dataset.id);
+    await detailPage.clickEditButton();
+
+    await page.getByRole("button", { name: "Legg til tidsperiode" }).click();
+    const dialog = page.getByRole("dialog");
+    const fromField = dialog.getByLabel("Fra", { exact: true });
+    const toField = dialog.getByLabel("Til", { exact: true });
+
+    const pasteInto = async (
+      locator: ReturnType<typeof page.locator>,
+      text: string,
+    ) => {
+      await locator.focus();
+      const dataTransfer = await page.evaluateHandle((value: string) => {
+        const dt = new DataTransfer();
+        dt.setData("text/plain", value);
+        return dt;
+      }, text);
+      await locator.dispatchEvent("paste", { dataTransfer });
+    };
+
+    await pasteInto(fromField, "2026 ");
+    await pasteInto(toField, " 15.06.2026");
+
+    await dialog.getByRole("button", { name: "Legg til" }).click();
+
+    await editPage.clickSaveButton();
+    await detailPage.goto(process.env.E2E_CATALOG_ID as string, dataset.id);
+    await detailPage.expectPeriod("2026", "15.06.2026");
+  },
+);
+
+runTestAsAdmin(
   "should edit dataset relations section",
   async ({ datasetsPage, playwright }) => {
     const dataset = await createRandomDataset(playwright);

--- a/apps/dataset-catalog-e2e/src/tests/admin/datasetEditPage.spec.ts
+++ b/apps/dataset-catalog-e2e/src/tests/admin/datasetEditPage.spec.ts
@@ -314,6 +314,70 @@ runTestAsAdmin(
 );
 
 runTestAsAdmin(
+  "should accept temporal values with year and year-month precision",
+  async ({ datasetsPage, playwright }) => {
+    const dataset = await createRandomDataset(playwright);
+    const detailPage: DatasetDetailPage = datasetsPage.detailPage;
+    const editPage: DatasetEditPage = datasetsPage.editPage;
+
+    await detailPage.goto(process.env.E2E_CATALOG_ID as string, dataset.id);
+    await detailPage.clickEditButton();
+
+    await editPage.addPeriod("2023", "06.2024");
+    await editPage.addPeriod("15.06.2024", "2025");
+
+    await editPage.clickSaveButton();
+
+    await detailPage.goto(process.env.E2E_CATALOG_ID as string, dataset.id);
+    await detailPage.expectPeriod("2023", "06.2024");
+    await detailPage.expectPeriod("15.06.2024", "2025");
+  },
+);
+
+runTestAsAdmin(
+  "should reject invalid temporal input",
+  async ({ datasetsPage, playwright, page }) => {
+    const dataset = await createRandomDataset(playwright);
+    const detailPage: DatasetDetailPage = datasetsPage.detailPage;
+
+    await detailPage.goto(process.env.E2E_CATALOG_ID as string, dataset.id);
+    await detailPage.clickEditButton();
+
+    await page.getByRole("button", { name: "Legg til tidsperiode" }).click();
+    const dialog = page.getByRole("dialog");
+    await dialog.getByLabel("Fra").fill("2024-");
+    await dialog.getByLabel("Til").fill("2023");
+
+    const addButton = dialog.getByRole("button", { name: "Legg til" });
+    await addButton.click();
+
+    await expect(
+      dialog.getByText(
+        "Ugyldig datoformat. Bruk åååå, mm.åååå eller dd.mm.åååå.",
+      ),
+    ).toBeVisible();
+  },
+);
+
+runTestAsAdmin(
+  "should expose a date picker button inside each temporal input",
+  async ({ datasetsPage, playwright, page }) => {
+    const dataset = await createRandomDataset(playwright);
+    const detailPage: DatasetDetailPage = datasetsPage.detailPage;
+
+    await detailPage.goto(process.env.E2E_CATALOG_ID as string, dataset.id);
+    await detailPage.clickEditButton();
+
+    await page.getByRole("button", { name: "Legg til tidsperiode" }).click();
+    const dialog = page.getByRole("dialog");
+
+    await expect(
+      dialog.getByRole("button", { name: "Åpne datovelger" }),
+    ).toHaveCount(2);
+  },
+);
+
+runTestAsAdmin(
   "should edit dataset relations section",
   async ({ datasetsPage, playwright }) => {
     const dataset = await createRandomDataset(playwright);

--- a/apps/dataset-catalog-e2e/src/tests/admin/datasetEditPage.spec.ts
+++ b/apps/dataset-catalog-e2e/src/tests/admin/datasetEditPage.spec.ts
@@ -403,45 +403,6 @@ runTestAsAdmin(
 );
 
 runTestAsAdmin(
-  "should trim whitespace from pasted temporal dates",
-  async ({ datasetsPage, playwright, page }) => {
-    const dataset = await createRandomDataset(playwright);
-    const detailPage: DatasetDetailPage = datasetsPage.detailPage;
-    const editPage: DatasetEditPage = datasetsPage.editPage;
-
-    await detailPage.goto(process.env.E2E_CATALOG_ID as string, dataset.id);
-    await detailPage.clickEditButton();
-
-    await page.getByRole("button", { name: "Legg til tidsperiode" }).click();
-    const dialog = page.getByRole("dialog");
-    const fromField = dialog.getByLabel("Fra", { exact: true });
-    const toField = dialog.getByLabel("Til", { exact: true });
-
-    const pasteInto = async (
-      locator: ReturnType<typeof page.locator>,
-      text: string,
-    ) => {
-      await locator.focus();
-      const dataTransfer = await page.evaluateHandle((value: string) => {
-        const dt = new DataTransfer();
-        dt.setData("text/plain", value);
-        return dt;
-      }, text);
-      await locator.dispatchEvent("paste", { dataTransfer });
-    };
-
-    await pasteInto(fromField, "2026 ");
-    await pasteInto(toField, " 15.06.2026");
-
-    await dialog.getByRole("button", { name: "Legg til" }).click();
-
-    await editPage.clickSaveButton();
-    await detailPage.goto(process.env.E2E_CATALOG_ID as string, dataset.id);
-    await detailPage.expectPeriod("2026", "15.06.2026");
-  },
-);
-
-runTestAsAdmin(
   "should edit dataset relations section",
   async ({ datasetsPage, playwright }) => {
     const dataset = await createRandomDataset(playwright);

--- a/apps/dataset-catalog-e2e/src/tests/admin/datasetEditPage.spec.ts
+++ b/apps/dataset-catalog-e2e/src/tests/admin/datasetEditPage.spec.ts
@@ -360,6 +360,25 @@ runTestAsAdmin(
 );
 
 runTestAsAdmin(
+  "should restrict temporal date input to digits, '.' and '/'",
+  async ({ datasetsPage, playwright, page }) => {
+    const dataset = await createRandomDataset(playwright);
+    const detailPage: DatasetDetailPage = datasetsPage.detailPage;
+
+    await detailPage.goto(process.env.E2E_CATALOG_ID as string, dataset.id);
+    await detailPage.clickEditButton();
+
+    await page.getByRole("button", { name: "Legg til tidsperiode" }).click();
+    const dialog = page.getByRole("dialog");
+    const fromField = dialog.getByLabel("Fra");
+
+    await fromField.pressSequentially("a1-2 3.4/5b");
+
+    await expect(fromField).toHaveValue("123.4/5");
+  },
+);
+
+runTestAsAdmin(
   "should expose a date picker button inside each temporal input",
   async ({ datasetsPage, playwright, page }) => {
     const dataset = await createRandomDataset(playwright);

--- a/apps/dataset-catalog-e2e/src/tests/admin/datasetEditPage.spec.ts
+++ b/apps/dataset-catalog-e2e/src/tests/admin/datasetEditPage.spec.ts
@@ -295,7 +295,7 @@ runTestAsAdmin(
     await editPage.checkLanguage("Nynorsk");
     await editPage.checkLanguage("Engelsk");
     await editPage.selectCoverageArea("Norge");
-    await editPage.addPeriod("2020-01-01", "2020-12-01");
+    await editPage.addPeriod("01.01.2020", "01.12.2020");
 
     // Save changes
     await editPage.clickSaveButton();
@@ -345,8 +345,8 @@ runTestAsAdmin(
 
     await page.getByRole("button", { name: "Legg til tidsperiode" }).click();
     const dialog = page.getByRole("dialog");
-    await dialog.getByLabel("Fra").fill("2024-");
-    await dialog.getByLabel("Til").fill("2023");
+    await dialog.getByLabel("Fra", { exact: true }).fill("32.01.2024");
+    await dialog.getByLabel("Til", { exact: true }).fill("2023");
 
     const addButton = dialog.getByRole("button", { name: "Legg til" });
     await addButton.click();
@@ -370,7 +370,7 @@ runTestAsAdmin(
 
     await page.getByRole("button", { name: "Legg til tidsperiode" }).click();
     const dialog = page.getByRole("dialog");
-    const fromField = dialog.getByLabel("Fra");
+    const fromField = dialog.getByLabel("Fra", { exact: true });
 
     await fromField.pressSequentially("a1-2 3.4/5b");
 
@@ -390,8 +390,14 @@ runTestAsAdmin(
     await page.getByRole("button", { name: "Legg til tidsperiode" }).click();
     const dialog = page.getByRole("dialog");
 
+    // includeHidden: Digdir's Textfield wraps suffix in `<FieldAffix aria-hidden>`,
+    // hiding the datepicker button from the ARIA tree. The button is still visible
+    // and focusable for sighted/keyboard users.
     await expect(
-      dialog.getByRole("button", { name: "Åpne datovelger" }),
+      dialog.getByRole("button", {
+        name: "Åpne datovelger",
+        includeHidden: true,
+      }),
     ).toHaveCount(2);
   },
 );

--- a/apps/dataset-catalog/components/dataset-form/components/details-section/date-field-with-picker.spec.ts
+++ b/apps/dataset-catalog/components/dataset-form/components/details-section/date-field-with-picker.spec.ts
@@ -1,0 +1,17 @@
+import { isAllowedDateChars } from "./date-field-with-picker.utils";
+
+describe("isAllowedDateChars", () => {
+  it.each([null, "", "1", "123", "01.02.2024", "01/02/2024", "."])(
+    "allows %p",
+    (value) => {
+      expect(isAllowedDateChars(value)).toBe(true);
+    },
+  );
+
+  it.each(["a", "-", "2024-06-15", "12 34", "ø", "1a", " ", "01.02.2024a"])(
+    "rejects %p",
+    (value) => {
+      expect(isAllowedDateChars(value)).toBe(false);
+    },
+  );
+});

--- a/apps/dataset-catalog/components/dataset-form/components/details-section/date-field-with-picker.spec.ts
+++ b/apps/dataset-catalog/components/dataset-form/components/details-section/date-field-with-picker.spec.ts
@@ -1,14 +1,23 @@
 import { isAllowedDateChars } from "./date-field-with-picker.utils";
 
 describe("isAllowedDateChars", () => {
-  it.each([null, "", "1", "123", "01.02.2024", "01/02/2024", "."])(
-    "allows %p",
-    (value) => {
-      expect(isAllowedDateChars(value)).toBe(true);
-    },
-  );
+  it.each([
+    null,
+    "",
+    "1",
+    "123",
+    "01.02.2024",
+    "01/02/2024",
+    ".",
+    " ",
+    "2026 ",
+    " 2026",
+    "12 34",
+  ])("allows %p", (value) => {
+    expect(isAllowedDateChars(value)).toBe(true);
+  });
 
-  it.each(["a", "-", "2024-06-15", "12 34", "ø", "1a", " ", "01.02.2024a"])(
+  it.each(["a", "-", "2024-06-15", "ø", "1a", "01.02.2024a"])(
     "rejects %p",
     (value) => {
       expect(isAllowedDateChars(value)).toBe(false);

--- a/apps/dataset-catalog/components/dataset-form/components/details-section/date-field-with-picker.tsx
+++ b/apps/dataset-catalog/components/dataset-form/components/details-section/date-field-with-picker.tsx
@@ -9,13 +9,15 @@ import { isAllowedDateChars } from "./date-field-with-picker.utils";
 
 interface DateFieldWithPickerProps {
   name: keyof DateRange;
-  label: ReactNode;
+  label: string;
+  helpText?: ReactNode;
   error?: ReactNode;
 }
 
 export const DateFieldWithPicker = ({
   name,
   label,
+  helpText,
   error,
 }: DateFieldWithPickerProps) => {
   const { setFieldValue } = useFormikContext<DateRange>();
@@ -50,7 +52,17 @@ export const DateFieldWithPicker = ({
       <FastField
         as={Textfield}
         data-size="sm"
-        label={label}
+        label={
+          helpText ? (
+            <span className={styles.labelWithHelp}>
+              {label}
+              {helpText}
+            </span>
+          ) : (
+            label
+          )
+        }
+        aria-label={label}
         type="text"
         name={name}
         autoComplete="off"

--- a/apps/dataset-catalog/components/dataset-form/components/details-section/date-field-with-picker.tsx
+++ b/apps/dataset-catalog/components/dataset-form/components/details-section/date-field-with-picker.tsx
@@ -65,6 +65,7 @@ export const DateFieldWithPicker = ({
         aria-label={label}
         type="text"
         name={name}
+        placeholder={localization.datasetForm.placeholder.temporalDate}
         autoComplete="off"
         error={error}
         onBeforeInput={handleBeforeInput}

--- a/apps/dataset-catalog/components/dataset-form/components/details-section/date-field-with-picker.tsx
+++ b/apps/dataset-catalog/components/dataset-form/components/details-section/date-field-with-picker.tsx
@@ -1,0 +1,75 @@
+import { DateRange } from "@catalog-frontend/types";
+import { formatFlexibleDate, localization } from "@catalog-frontend/utils";
+import { Textfield } from "@digdir/designsystemet-react";
+import { CalendarIcon } from "@navikt/aksel-icons";
+import { FastField, useFormikContext } from "formik";
+import { ChangeEvent, ReactNode, useRef } from "react";
+import styles from "../../dataset-form.module.css";
+
+interface DateFieldWithPickerProps {
+  name: keyof DateRange;
+  label: string;
+  description: string;
+  error?: ReactNode;
+}
+
+export const DateFieldWithPicker = ({
+  name,
+  label,
+  description,
+  error,
+}: DateFieldWithPickerProps) => {
+  const { setFieldValue } = useFormikContext<DateRange>();
+  const hiddenRef = useRef<HTMLInputElement>(null);
+
+  const handlePickerChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const iso = e.target.value;
+
+    if (!iso) {
+      return;
+    }
+
+    const formatted = formatFlexibleDate(iso);
+
+    if (formatted) {
+      setFieldValue(name, formatted);
+    }
+
+    e.target.value = "";
+  };
+
+  return (
+    <div className={styles.dateFieldWithPicker}>
+      <FastField
+        as={Textfield}
+        data-size="sm"
+        label={label}
+        description={description}
+        type="text"
+        name={name}
+        autoComplete="off"
+        error={error}
+        suffix={
+          <button
+            type="button"
+            className={styles.dateIconButton}
+            aria-label={localization.datasetForm.button.openDatePicker}
+            onClick={() => hiddenRef.current?.showPicker()}
+          >
+            <CalendarIcon aria-hidden fontSize="1.25rem" />
+          </button>
+        }
+      />
+
+      <input
+        type="date"
+        ref={hiddenRef}
+        className={styles.hiddenDateInput}
+        tabIndex={-1}
+        aria-hidden
+        defaultValue=""
+        onChange={handlePickerChange}
+      />
+    </div>
+  );
+};

--- a/apps/dataset-catalog/components/dataset-form/components/details-section/date-field-with-picker.tsx
+++ b/apps/dataset-catalog/components/dataset-form/components/details-section/date-field-with-picker.tsx
@@ -3,20 +3,19 @@ import { formatFlexibleDate, localization } from "@catalog-frontend/utils";
 import { Textfield } from "@digdir/designsystemet-react";
 import { CalendarIcon } from "@navikt/aksel-icons";
 import { FastField, useFormikContext } from "formik";
-import { ChangeEvent, ReactNode, useRef } from "react";
+import { ChangeEvent, FormEvent, ReactNode, useRef } from "react";
 import styles from "../../dataset-form.module.css";
+import { isAllowedDateChars } from "./date-field-with-picker.utils";
 
 interface DateFieldWithPickerProps {
   name: keyof DateRange;
-  label: string;
-  description: string;
+  label: ReactNode;
   error?: ReactNode;
 }
 
 export const DateFieldWithPicker = ({
   name,
   label,
-  description,
   error,
 }: DateFieldWithPickerProps) => {
   const { setFieldValue } = useFormikContext<DateRange>();
@@ -38,17 +37,25 @@ export const DateFieldWithPicker = ({
     e.target.value = "";
   };
 
+  const handleBeforeInput = (e: FormEvent<HTMLInputElement>) => {
+    // beforeinput always dispatches a native InputEvent; cast at the DOM boundary.
+    const data = (e.nativeEvent as InputEvent).data;
+    if (!isAllowedDateChars(data)) {
+      e.preventDefault();
+    }
+  };
+
   return (
     <div className={styles.dateFieldWithPicker}>
       <FastField
         as={Textfield}
         data-size="sm"
         label={label}
-        description={description}
         type="text"
         name={name}
         autoComplete="off"
         error={error}
+        onBeforeInput={handleBeforeInput}
         suffix={
           <button
             type="button"

--- a/apps/dataset-catalog/components/dataset-form/components/details-section/date-field-with-picker.tsx
+++ b/apps/dataset-catalog/components/dataset-form/components/details-section/date-field-with-picker.tsx
@@ -12,6 +12,7 @@ interface DateFieldWithPickerProps {
   label: string;
   helpText?: ReactNode;
   error?: ReactNode;
+  autoFocus?: boolean;
 }
 
 export const DateFieldWithPicker = ({
@@ -19,6 +20,7 @@ export const DateFieldWithPicker = ({
   label,
   helpText,
   error,
+  autoFocus,
 }: DateFieldWithPickerProps) => {
   const { setFieldValue } = useFormikContext<DateRange>();
   const hiddenRef = useRef<HTMLInputElement>(null);
@@ -67,6 +69,7 @@ export const DateFieldWithPicker = ({
         name={name}
         placeholder={localization.datasetForm.placeholder.temporalDate}
         autoComplete="off"
+        autoFocus={autoFocus}
         error={error}
         onBeforeInput={handleBeforeInput}
         suffix={

--- a/apps/dataset-catalog/components/dataset-form/components/details-section/date-field-with-picker.utils.ts
+++ b/apps/dataset-catalog/components/dataset-form/components/details-section/date-field-with-picker.utils.ts
@@ -1,0 +1,4 @@
+const allowedDateChars = /^[\d./]*$/;
+
+export const isAllowedDateChars = (data: string | null): boolean =>
+  data === null || allowedDateChars.test(data);

--- a/apps/dataset-catalog/components/dataset-form/components/details-section/date-field-with-picker.utils.ts
+++ b/apps/dataset-catalog/components/dataset-form/components/details-section/date-field-with-picker.utils.ts
@@ -1,4 +1,4 @@
-const allowedDateChars = /^[\d./]*$/;
+const allowedDateChars = /^[\d./\s]*$/;
 
 export const isAllowedDateChars = (data: string | null): boolean =>
   data === null || allowedDateChars.test(data);

--- a/apps/dataset-catalog/components/dataset-form/components/details-section/temporal-modal.tsx
+++ b/apps/dataset-catalog/components/dataset-form/components/details-section/temporal-modal.tsx
@@ -163,7 +163,11 @@ const FieldModal = ({ template, type, onSuccess, onCancel }: ModalProps) => {
             <AddButton>{localization.datasetForm.button.addDate}</AddButton>
           )}
         </Dialog.Trigger>
-        <Dialog ref={modalRef} onClose={() => formikRef.current?.resetForm()}>
+        <Dialog
+          ref={modalRef}
+          className={styles.temporalDialog}
+          onClose={() => formikRef.current?.resetForm()}
+        >
           <Formik
             innerRef={formikRef}
             initialValues={displayTemplate}

--- a/apps/dataset-catalog/components/dataset-form/components/details-section/temporal-modal.tsx
+++ b/apps/dataset-catalog/components/dataset-form/components/details-section/temporal-modal.tsx
@@ -14,7 +14,7 @@ import {
   trimObjectWhitespace,
 } from "@catalog-frontend/utils";
 import { Button, Dialog, Heading, Table } from "@digdir/designsystemet-react";
-import { FieldArray, Formik, useFormikContext } from "formik";
+import { FieldArray, Formik, FormikProps, useFormikContext } from "formik";
 import styles from "../../dataset-form.module.css";
 import { ReactNode, useRef, useState } from "react";
 import { get, isEmpty } from "lodash";
@@ -146,6 +146,7 @@ const normalizeToCanonical = (value: string | undefined): string => {
 
 const FieldModal = ({ template, type, onSuccess, onCancel }: ModalProps) => {
   const modalRef = useRef<HTMLDialogElement>(null);
+  const formikRef = useRef<FormikProps<DateRange>>(null);
 
   const displayTemplate: DateRange = {
     startDate: toDisplayForm(template.startDate),
@@ -162,8 +163,9 @@ const FieldModal = ({ template, type, onSuccess, onCancel }: ModalProps) => {
             <AddButton>{localization.datasetForm.button.addDate}</AddButton>
           )}
         </Dialog.Trigger>
-        <Dialog ref={modalRef}>
+        <Dialog ref={modalRef} onClose={() => formikRef.current?.resetForm()}>
           <Formik
+            innerRef={formikRef}
             initialValues={displayTemplate}
             enableReinitialize={true}
             validateOnChange={false}

--- a/apps/dataset-catalog/components/dataset-form/components/details-section/temporal-modal.tsx
+++ b/apps/dataset-catalog/components/dataset-form/components/details-section/temporal-modal.tsx
@@ -193,19 +193,14 @@ const FieldModal = ({ template, type, onSuccess, onCancel }: ModalProps) => {
                   <div className={cn(styles.modalContent, styles.calendar)}>
                     <DateFieldWithPicker
                       name="startDate"
-                      label={
-                        <span className={styles.labelWithHelp}>
-                          {localization.from}
-                          <HelpMarkdown
-                            aria-label={localization.helpWithCompleting}
-                            placement="top-end"
-                          >
-                            {
-                              localization.datasetForm.helptext
-                                .temporalDateFormat
-                            }
-                          </HelpMarkdown>
-                        </span>
+                      label={localization.from}
+                      helpText={
+                        <HelpMarkdown
+                          aria-label={localization.helpWithCompleting}
+                          placement="top-end"
+                        >
+                          {localization.datasetForm.helptext.temporalDateFormat}
+                        </HelpMarkdown>
                       }
                       error={errors.startDate}
                     />
@@ -214,19 +209,14 @@ const FieldModal = ({ template, type, onSuccess, onCancel }: ModalProps) => {
 
                     <DateFieldWithPicker
                       name="endDate"
-                      label={
-                        <span className={styles.labelWithHelp}>
-                          {localization.to}
-                          <HelpMarkdown
-                            aria-label={localization.helpWithCompleting}
-                            placement="top-end"
-                          >
-                            {
-                              localization.datasetForm.helptext
-                                .temporalDateFormat
-                            }
-                          </HelpMarkdown>
-                        </span>
+                      label={localization.to}
+                      helpText={
+                        <HelpMarkdown
+                          aria-label={localization.helpWithCompleting}
+                          placement="top-end"
+                        >
+                          {localization.datasetForm.helptext.temporalDateFormat}
+                        </HelpMarkdown>
                       }
                       error={errors.endDate}
                     />

--- a/apps/dataset-catalog/components/dataset-form/components/details-section/temporal-modal.tsx
+++ b/apps/dataset-catalog/components/dataset-form/components/details-section/temporal-modal.tsx
@@ -5,6 +5,7 @@ import {
   EditButton,
   FormHeading,
   DialogActions,
+  HelpMarkdown,
 } from "@catalog-frontend/ui";
 import {
   formatFlexibleDate,
@@ -125,13 +126,16 @@ export const TemporalModal = ({ label }: Props) => {
 };
 
 const canonicalIsoRegex = /^\d{4}(-\d{2}(-\d{2})?)?$/;
-const dateHint = "åååå / mm.åååå / dd.mm.åååå";
 
 const toDisplayForm = (value: string | undefined): string => {
-  if (!value) return "";
+  if (!value) {
+    return "";
+  }
+
   if (canonicalIsoRegex.test(value)) {
     return formatFlexibleDate(value) ?? value;
   }
+
   return value;
 };
 
@@ -189,8 +193,20 @@ const FieldModal = ({ template, type, onSuccess, onCancel }: ModalProps) => {
                   <div className={cn(styles.modalContent, styles.calendar)}>
                     <DateFieldWithPicker
                       name="startDate"
-                      label={localization.from}
-                      description={dateHint}
+                      label={
+                        <span className={styles.labelWithHelp}>
+                          {localization.from}
+                          <HelpMarkdown
+                            aria-label={localization.helpWithCompleting}
+                            placement="top-end"
+                          >
+                            {
+                              localization.datasetForm.helptext
+                                .temporalDateFormat
+                            }
+                          </HelpMarkdown>
+                        </span>
+                      }
                       error={errors.startDate}
                     />
 
@@ -198,8 +214,20 @@ const FieldModal = ({ template, type, onSuccess, onCancel }: ModalProps) => {
 
                     <DateFieldWithPicker
                       name="endDate"
-                      label={localization.to}
-                      description={dateHint}
+                      label={
+                        <span className={styles.labelWithHelp}>
+                          {localization.to}
+                          <HelpMarkdown
+                            aria-label={localization.helpWithCompleting}
+                            placement="top-end"
+                          >
+                            {
+                              localization.datasetForm.helptext
+                                .temporalDateFormat
+                            }
+                          </HelpMarkdown>
+                        </span>
+                      }
                       error={errors.endDate}
                     />
                   </div>

--- a/apps/dataset-catalog/components/dataset-form/components/details-section/temporal-modal.tsx
+++ b/apps/dataset-catalog/components/dataset-form/components/details-section/temporal-modal.tsx
@@ -7,24 +7,20 @@ import {
   DialogActions,
 } from "@catalog-frontend/ui";
 import {
-  formatDateToDDMMYYYY,
+  formatFlexibleDate,
   localization,
+  toCanonicalFlexibleISO,
   trimObjectWhitespace,
 } from "@catalog-frontend/utils";
-import {
-  Button,
-  Dialog,
-  Heading,
-  Table,
-  Textfield,
-} from "@digdir/designsystemet-react";
-import { FastField, FieldArray, Formik, useFormikContext } from "formik";
+import { Button, Dialog, Heading, Table } from "@digdir/designsystemet-react";
+import { FieldArray, Formik, useFormikContext } from "formik";
 import styles from "../../dataset-form.module.css";
-import { ReactNode, useEffect, useRef, useState } from "react";
+import { ReactNode, useRef, useState } from "react";
 import { get, isEmpty } from "lodash";
 import { dateSchema } from "../../utils/validation-schema";
 import cn from "classnames";
 import { MinusIcon } from "@navikt/aksel-icons";
+import { DateFieldWithPicker } from "./date-field-with-picker";
 
 interface Props {
   label?: string | ReactNode;
@@ -35,7 +31,6 @@ interface ModalProps {
   type: "new" | "edit";
   onSuccess: (values: DateRange) => void;
   onCancel: () => void;
-  onChange: (values: DateRange) => void;
   template: DateRange;
 }
 
@@ -71,13 +66,11 @@ export const TemporalModal = ({ label }: Props) => {
                     <Table.Row key={`temporal-tableRow-${index}`}>
                       <Table.Cell>
                         {item?.startDate
-                          ? formatDateToDDMMYYYY(item.startDate)
+                          ? formatFlexibleDate(item.startDate)
                           : "-"}
                       </Table.Cell>
                       <Table.Cell>
-                        {item?.endDate
-                          ? formatDateToDDMMYYYY(item.endDate)
-                          : "-"}
+                        {item?.endDate ? formatFlexibleDate(item.endDate) : "-"}
                       </Table.Cell>
                       <Table.Cell>
                         <span className={styles.set}>
@@ -86,12 +79,13 @@ export const TemporalModal = ({ label }: Props) => {
                             type="edit"
                             onSuccess={(updatedItem: DateRange) => {
                               arrayHelpers.replace(index, updatedItem);
-                              setSnapshot([...(values.temporal ?? [])]);
+                              setSnapshot((prev) => {
+                                const next = [...prev];
+                                next[index] = updatedItem;
+                                return next;
+                              });
                             }}
                             onCancel={() => setFieldValue("temporal", snapshot)}
-                            onChange={(updatedItem: DateRange) =>
-                              arrayHelpers.replace(index, updatedItem)
-                            }
                           />
                           <DeleteButton
                             onClick={() => {
@@ -112,15 +106,15 @@ export const TemporalModal = ({ label }: Props) => {
               <FieldModal
                 template={{ startDate: "", endDate: "" }}
                 type="new"
-                onSuccess={() => setSnapshot([...(values.temporal ?? [])])}
-                onCancel={() => setFieldValue("temporal", snapshot)}
-                onChange={(updatedItem: DateRange) => {
+                onSuccess={(newItem: DateRange) => {
                   if (snapshot.length === (values.temporal?.length ?? 0)) {
-                    arrayHelpers.push(updatedItem);
+                    arrayHelpers.push(newItem);
                   } else {
-                    arrayHelpers.replace(snapshot.length, updatedItem);
+                    arrayHelpers.replace(snapshot.length, newItem);
                   }
+                  setSnapshot((prev) => [...prev, newItem]);
                 }}
+                onCancel={() => setFieldValue("temporal", snapshot)}
               />
             </div>
           </div>
@@ -130,15 +124,29 @@ export const TemporalModal = ({ label }: Props) => {
   );
 };
 
-const FieldModal = ({
-  template,
-  type,
-  onSuccess,
-  onCancel,
-  onChange,
-}: ModalProps) => {
-  const [submitted, setSubmitted] = useState(false);
+const canonicalIsoRegex = /^\d{4}(-\d{2}(-\d{2})?)?$/;
+const dateHint = "åååå / mm.åååå / dd.mm.åååå";
+
+const toDisplayForm = (value: string | undefined): string => {
+  if (!value) return "";
+  if (canonicalIsoRegex.test(value)) {
+    return formatFlexibleDate(value) ?? value;
+  }
+  return value;
+};
+
+const normalizeToCanonical = (value: string | undefined): string => {
+  if (!value) return "";
+  return toCanonicalFlexibleISO(value) ?? value;
+};
+
+const FieldModal = ({ template, type, onSuccess, onCancel }: ModalProps) => {
   const modalRef = useRef<HTMLDialogElement>(null);
+
+  const displayTemplate: DateRange = {
+    startDate: toDisplayForm(template.startDate),
+    endDate: toDisplayForm(template.endDate),
+  };
 
   return (
     <>
@@ -152,27 +160,24 @@ const FieldModal = ({
         </Dialog.Trigger>
         <Dialog ref={modalRef}>
           <Formik
-            initialValues={template}
+            initialValues={displayTemplate}
             enableReinitialize={true}
-            validateOnChange={submitted}
-            validateOnBlur={submitted}
+            validateOnChange={false}
+            validateOnBlur={false}
             validationSchema={dateSchema}
             onSubmit={(formValues, { setSubmitting, resetForm }) => {
               const trimmedValues = trimObjectWhitespace(formValues);
-              onSuccess(trimmedValues);
+              const normalized: DateRange = {
+                startDate: normalizeToCanonical(trimmedValues.startDate),
+                endDate: normalizeToCanonical(trimmedValues.endDate),
+              };
+              onSuccess(normalized);
               setSubmitting(false);
-              setSubmitted(true);
               resetForm();
               modalRef.current?.close();
             }}
           >
             {({ isSubmitting, submitForm, values, dirty, errors }) => {
-              useEffect(() => {
-                if (dirty && modalRef.current?.open) {
-                  onChange({ ...values });
-                }
-              }, [values, dirty]);
-
               return (
                 <>
                   <Heading data-size="xs">
@@ -182,25 +187,20 @@ const FieldModal = ({
                   </Heading>
 
                   <div className={cn(styles.modalContent, styles.calendar)}>
-                    <FastField
-                      as={Textfield}
-                      data-size="sm"
-                      label={localization.from}
-                      type="date"
+                    <DateFieldWithPicker
                       name="startDate"
+                      label={localization.from}
+                      description={dateHint}
                       error={errors.startDate}
                     />
 
                     <MinusIcon title="minus-icon" fontSize="1rem" />
 
-                    <FastField
-                      as={Textfield}
-                      data-size="sm"
-                      label={localization.to}
-                      type="date"
+                    <DateFieldWithPicker
                       name="endDate"
+                      label={localization.to}
+                      description={dateHint}
                       error={errors.endDate}
-                      min={values.startDate}
                     />
                   </div>
 

--- a/apps/dataset-catalog/components/dataset-form/components/details-section/temporal-modal.tsx
+++ b/apps/dataset-catalog/components/dataset-form/components/details-section/temporal-modal.tsx
@@ -200,6 +200,7 @@ const FieldModal = ({ template, type, onSuccess, onCancel }: ModalProps) => {
                     <DateFieldWithPicker
                       name="startDate"
                       label={localization.from}
+                      autoFocus
                       helpText={
                         <HelpMarkdown
                           aria-label={localization.helpWithCompleting}

--- a/apps/dataset-catalog/components/dataset-form/dataset-form.module.css
+++ b/apps/dataset-catalog/components/dataset-form/dataset-form.module.css
@@ -82,9 +82,58 @@
   display: flex;
   flex-direction: row;
   gap: 1rem;
+  align-items: flex-start;
   & > svg {
-    padding-top: 2.5rem;
+    padding-top: 4.5rem;
   }
+}
+
+.dateFieldWithPicker {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+}
+
+.dateFieldWithPicker
+  :global(
+    .ds-field-affixes:has(.ds-input[aria-invalid="true"]) .ds-field-affix
+  ) {
+  border-color: var(--dsc-input-accent-color--invalid);
+}
+
+.dateIconButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.5rem;
+  height: 1.5rem;
+  padding: 0;
+  background: transparent;
+  border: none;
+  border-radius: var(--ds-border-radius-sm);
+  color: var(--ds-color-neutral-text-default);
+  cursor: pointer;
+}
+
+.dateIconButton:hover {
+  background: var(--ds-color-neutral-surface-hover);
+}
+
+.dateIconButton:focus-visible {
+  outline: 2px solid var(--ds-color-focus-inner);
+  outline-offset: 2px;
+}
+
+.hiddenDateInput {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 .errorBorder {

--- a/apps/dataset-catalog/components/dataset-form/dataset-form.module.css
+++ b/apps/dataset-catalog/components/dataset-form/dataset-form.module.css
@@ -78,6 +78,10 @@
   margin: var(--ds-size-8) 0;
 }
 
+.temporalDialog {
+  --dsc-dialog-max-width: 44rem;
+}
+
 .notification {
   background: none;
   border: none;
@@ -98,6 +102,7 @@
   display: flex;
   flex-direction: column;
   flex: 1;
+  min-width: 16rem;
 }
 
 .dateFieldWithPicker

--- a/apps/dataset-catalog/components/dataset-form/dataset-form.module.css
+++ b/apps/dataset-catalog/components/dataset-form/dataset-form.module.css
@@ -28,6 +28,12 @@
   display: flex;
 }
 
+.labelWithHelp {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
 .hiddenField {
   padding-bottom: 1rem;
   padding-top: 0.5rem;
@@ -84,7 +90,7 @@
   gap: 1rem;
   align-items: flex-start;
   & > svg {
-    padding-top: 4.5rem;
+    padding-top: 3rem;
   }
 }
 

--- a/apps/dataset-catalog/components/dataset-form/utils/validation-schema.tsx
+++ b/apps/dataset-catalog/components/dataset-form/utils/validation-schema.tsx
@@ -1,7 +1,8 @@
 import {
+  FlexiblePrecision,
   httpsRegex,
   localization,
-  parseDateTime,
+  parseFlexibleDate,
   telephoneNumberRegex,
 } from "@catalog-frontend/utils";
 import * as Yup from "yup";
@@ -187,6 +188,11 @@ export const referenceSchema = Yup.object().shape({
   source: Yup.string().required(localization.datasetForm.validation.relation),
 });
 
+const precisionToUnit = (
+  precision: FlexiblePrecision,
+): "year" | "month" | "day" =>
+  precision === "yearMonth" ? "month" : precision === "year" ? "year" : "day";
+
 export const dateSchema = Yup.object().shape({
   startDate: Yup.mixed()
     .nullable()
@@ -196,13 +202,12 @@ export const dateSchema = Yup.object().shape({
           return true;
         }
 
-        const startDateTime = parseDateTime(value);
-        if (startDateTime?.isValid) {
+        if (parseFlexibleDate(value as string)) {
           return true;
         }
 
         return this.createError({
-          message: localization.conceptForm.validation.date,
+          message: localization.datasetForm.validation.temporalDateFormat,
           path: this.path,
         });
       },
@@ -211,23 +216,34 @@ export const dateSchema = Yup.object().shape({
     .nullable()
     .test({
       test(value) {
-        if (!value && this.parent.startDate) {
+        if (!value) {
           return true;
         }
 
-        const endDateTime = parseDateTime(value);
-        if (endDateTime?.isValid) {
-          const startDateTime = parseDateTime(this.parent.startDate);
-          if (!startDateTime?.isValid) {
-            return true;
-          }
-          if (endDateTime.toJSDate() >= startDateTime?.toJSDate()) {
-            return true;
-          }
+        const end = parseFlexibleDate(value as string);
+        if (!end) {
+          return this.createError({
+            message: localization.datasetForm.validation.temporalDateFormat,
+            path: this.path,
+          });
+        }
+
+        const start = parseFlexibleDate(this.parent.startDate);
+        if (!start) {
+          return true;
+        }
+
+        const endBoundary = end.dateTime.endOf(precisionToUnit(end.precision));
+        const startBoundary = start.dateTime.startOf(
+          precisionToUnit(start.precision),
+        );
+
+        if (endBoundary >= startBoundary) {
+          return true;
         }
 
         return this.createError({
-          message: localization.conceptForm.validation.date,
+          message: localization.datasetForm.validation.temporalDateOrder,
           path: this.path,
         });
       },

--- a/apps/dataset-catalog/components/details-page-columns/components/temporal-details.tsx
+++ b/apps/dataset-catalog/components/details-page-columns/components/temporal-details.tsx
@@ -1,5 +1,5 @@
 import { DateRange } from "@catalog-frontend/types";
-import { formatDate, localization } from "@catalog-frontend/utils";
+import { formatFlexibleDate, localization } from "@catalog-frontend/utils";
 import { Table } from "@digdir/designsystemet-react";
 import styles from "../details-columns.module.css";
 
@@ -22,23 +22,16 @@ export const TemporalDetails = ({ temporal }: Props) => {
           <Table.Body>
             {temporal
               .filter((item) => item?.startDate || item?.endDate)
-              .map((item, index) => {
-                const startDate = item?.startDate
-                  ? new Date(item.startDate)
-                  : null;
-                const endDate = item?.endDate ? new Date(item.endDate) : null;
-
-                return (
-                  <Table.Row key={`tableRow-temporal-${index}`}>
-                    <Table.Cell>
-                      {startDate ? formatDate(startDate) : "-"}
-                    </Table.Cell>
-                    <Table.Cell>
-                      {endDate ? formatDate(endDate) : "-"}
-                    </Table.Cell>
-                  </Table.Row>
-                );
-              })}
+              .map((item, index) => (
+                <Table.Row key={`tableRow-temporal-${index}`}>
+                  <Table.Cell>
+                    {formatFlexibleDate(item?.startDate) ?? "-"}
+                  </Table.Cell>
+                  <Table.Cell>
+                    {formatFlexibleDate(item?.endDate) ?? "-"}
+                  </Table.Cell>
+                </Table.Row>
+              ))}
           </Table.Body>
         </Table>
       ) : undefined}

--- a/libs/utils/src/lib/date/format.spec.ts
+++ b/libs/utils/src/lib/date/format.spec.ts
@@ -1,0 +1,134 @@
+import {
+  formatFlexibleDate,
+  parseFlexibleDate,
+  toCanonicalFlexibleISO,
+} from "./format";
+
+describe("parseFlexibleDate", () => {
+  test("parses ISO yyyy-MM-dd as date precision", () => {
+    const parsed = parseFlexibleDate("2024-06-15");
+    expect(parsed?.precision).toBe("date");
+    expect(parsed?.iso).toBe("2024-06-15");
+  });
+
+  test("parses ISO yyyy-MM as yearMonth precision", () => {
+    const parsed = parseFlexibleDate("2024-06");
+    expect(parsed?.precision).toBe("yearMonth");
+    expect(parsed?.iso).toBe("2024-06");
+  });
+
+  test("parses ISO yyyy as year precision", () => {
+    const parsed = parseFlexibleDate("2024");
+    expect(parsed?.precision).toBe("year");
+    expect(parsed?.iso).toBe("2024");
+  });
+
+  test("parses Norwegian dd.MM.yyyy as date precision", () => {
+    const parsed = parseFlexibleDate("15.06.2024");
+    expect(parsed?.precision).toBe("date");
+    expect(parsed?.iso).toBe("2024-06-15");
+  });
+
+  test("parses Norwegian MM.yyyy as yearMonth precision", () => {
+    const parsed = parseFlexibleDate("06.2024");
+    expect(parsed?.precision).toBe("yearMonth");
+    expect(parsed?.iso).toBe("2024-06");
+  });
+
+  test("accepts slash separators (ISO style)", () => {
+    expect(parseFlexibleDate("2024/06/15")?.iso).toBe("2024-06-15");
+    expect(parseFlexibleDate("2024/06")?.iso).toBe("2024-06");
+  });
+
+  test("accepts slash separators (Norwegian style)", () => {
+    expect(parseFlexibleDate("15/06/2024")?.iso).toBe("2024-06-15");
+    expect(parseFlexibleDate("06/2024")?.iso).toBe("2024-06");
+  });
+
+  test("accepts JS Date objects", () => {
+    const date = new Date(Date.UTC(2024, 5, 15, 12));
+    const parsed = parseFlexibleDate(date);
+    expect(parsed?.precision).toBe("date");
+    expect(parsed?.iso).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  test("trims whitespace", () => {
+    expect(parseFlexibleDate("  15.06.2024  ")?.iso).toBe("2024-06-15");
+  });
+
+  test("rejects empty and null", () => {
+    expect(parseFlexibleDate("")).toBeNull();
+    expect(parseFlexibleDate("   ")).toBeNull();
+    expect(parseFlexibleDate(null)).toBeNull();
+    expect(parseFlexibleDate(undefined)).toBeNull();
+  });
+
+  test("rejects partial and malformed input", () => {
+    expect(parseFlexibleDate("2024-")).toBeNull();
+    expect(parseFlexibleDate("24")).toBeNull();
+    expect(parseFlexibleDate("2024.")).toBeNull();
+    expect(parseFlexibleDate("6.2024")).toBeNull();
+    expect(parseFlexibleDate("2024-6-15")).toBeNull();
+    expect(parseFlexibleDate("abc")).toBeNull();
+  });
+
+  test("rejects invalid calendar dates", () => {
+    expect(parseFlexibleDate("32.01.2024")).toBeNull();
+    expect(parseFlexibleDate("00.01.2024")).toBeNull();
+    expect(parseFlexibleDate("13.2024")).toBeNull();
+    expect(parseFlexibleDate("29.02.2023")).toBeNull();
+    expect(parseFlexibleDate("2023-02-29")).toBeNull();
+  });
+
+  test("accepts leap year Feb 29", () => {
+    expect(parseFlexibleDate("29.02.2024")?.iso).toBe("2024-02-29");
+    expect(parseFlexibleDate("2024-02-29")?.iso).toBe("2024-02-29");
+  });
+
+  test("rejects ISO datetime with time component", () => {
+    expect(parseFlexibleDate("2024-06-15T00:00:00Z")).toBeNull();
+  });
+});
+
+describe("toCanonicalFlexibleISO", () => {
+  test("normalizes accepted formats to canonical ISO", () => {
+    expect(toCanonicalFlexibleISO("2024")).toBe("2024");
+    expect(toCanonicalFlexibleISO("06.2024")).toBe("2024-06");
+    expect(toCanonicalFlexibleISO("15.06.2024")).toBe("2024-06-15");
+    expect(toCanonicalFlexibleISO("2024-06-15")).toBe("2024-06-15");
+  });
+
+  test("returns null for invalid input", () => {
+    expect(toCanonicalFlexibleISO("abc")).toBeNull();
+    expect(toCanonicalFlexibleISO("2024-")).toBeNull();
+  });
+});
+
+describe("formatFlexibleDate", () => {
+  test("formats canonical year to year display", () => {
+    expect(formatFlexibleDate("2024")).toBe("2024");
+  });
+
+  test("formats canonical yearMonth to MM.yyyy", () => {
+    expect(formatFlexibleDate("2024-06")).toBe("06.2024");
+  });
+
+  test("formats canonical date to dd.MM.yyyy", () => {
+    expect(formatFlexibleDate("2024-06-15")).toBe("15.06.2024");
+  });
+
+  test("is idempotent on display-form input", () => {
+    expect(formatFlexibleDate("2024")).toBe("2024");
+    expect(formatFlexibleDate("06.2024")).toBe("06.2024");
+    expect(formatFlexibleDate("15.06.2024")).toBe("15.06.2024");
+  });
+
+  test("returns null for empty input", () => {
+    expect(formatFlexibleDate(undefined)).toBeNull();
+    expect(formatFlexibleDate("")).toBeNull();
+  });
+
+  test("falls back to dd.MM.yyyy for full ISO datetime (legacy data)", () => {
+    expect(formatFlexibleDate("2024-06-15T00:00:00Z")).toBe("15.06.2024");
+  });
+});

--- a/libs/utils/src/lib/date/format.ts
+++ b/libs/utils/src/lib/date/format.ts
@@ -73,3 +73,114 @@ export const formatDateToDDMMYYYY = (isoDate: string | undefined) => {
   const date = DateTime.fromISO(isoDate);
   return date.isValid ? date.toFormat("dd.MM.yyyy") : null;
 };
+
+export type FlexiblePrecision = "year" | "yearMonth" | "date";
+
+export interface FlexibleParsed {
+  dateTime: DateTime;
+  precision: FlexiblePrecision;
+  iso: string;
+}
+
+type FlexibleVariant = {
+  pattern: RegExp;
+  source: "iso" | "nor";
+  luxonFormat: string;
+  precision: FlexiblePrecision;
+};
+
+const flexibleVariants: FlexibleVariant[] = [
+  {
+    pattern: /^\d{4}-\d{2}-\d{2}$/,
+    source: "iso",
+    luxonFormat: "yyyy-MM-dd",
+    precision: "date",
+  },
+  {
+    pattern: /^\d{4}-\d{2}$/,
+    source: "iso",
+    luxonFormat: "yyyy-MM",
+    precision: "yearMonth",
+  },
+  { pattern: /^\d{4}$/, source: "iso", luxonFormat: "yyyy", precision: "year" },
+  {
+    pattern: /^\d{2}\.\d{2}\.\d{4}$/,
+    source: "nor",
+    luxonFormat: "dd.MM.yyyy",
+    precision: "date",
+  },
+  {
+    pattern: /^\d{2}\.\d{4}$/,
+    source: "nor",
+    luxonFormat: "MM.yyyy",
+    precision: "yearMonth",
+  },
+];
+
+const isoFormatFor = (precision: FlexiblePrecision): string =>
+  precision === "date"
+    ? "yyyy-MM-dd"
+    : precision === "yearMonth"
+      ? "yyyy-MM"
+      : "yyyy";
+
+export const parseFlexibleDate = (
+  value: string | Date | null | undefined,
+): FlexibleParsed | null => {
+  if (!value) return null;
+
+  if (value instanceof Date) {
+    const dt = DateTime.fromJSDate(value);
+    return dt.isValid
+      ? { dateTime: dt, precision: "date", iso: dt.toFormat("yyyy-MM-dd") }
+      : null;
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+
+  const candidates = {
+    iso: trimmed.replace(/\//g, "-"),
+    nor: trimmed.replace(/\//g, "."),
+  };
+
+  for (const variant of flexibleVariants) {
+    const input = candidates[variant.source];
+    if (!variant.pattern.test(input)) continue;
+    const dt = DateTime.fromFormat(input, variant.luxonFormat);
+    if (dt.isValid) {
+      return {
+        dateTime: dt,
+        precision: variant.precision,
+        iso: dt.toFormat(isoFormatFor(variant.precision)),
+      };
+    }
+  }
+
+  return null;
+};
+
+export const toCanonicalFlexibleISO = (value: string): string | null =>
+  parseFlexibleDate(value)?.iso ?? null;
+
+export const formatFlexibleDate = (
+  value: string | undefined,
+): string | null => {
+  if (!value) {
+    return null;
+  }
+
+  const parsed = parseFlexibleDate(value);
+
+  if (parsed) {
+    switch (parsed.precision) {
+      case "year":
+        return parsed.dateTime.toFormat("yyyy");
+      case "yearMonth":
+        return parsed.dateTime.toFormat("MM.yyyy");
+      case "date":
+        return parsed.dateTime.toFormat("dd.MM.yyyy");
+    }
+  }
+  return formatDateToDDMMYYYY(value);
+};

--- a/libs/utils/src/lib/language/dataset.form.nb.ts
+++ b/libs/utils/src/lib/language/dataset.form.nb.ts
@@ -228,9 +228,13 @@ Dersom man velger en åpen lisens, vil datasettet bli merket med "Åpne data".`,
     distribution: "Distribusjon er påkrevd.",
     spatial: "Minst ett dekningsområde må velges.",
     frequency: "Oppdateringsfrekvens må velges.",
+    temporalDateFormat:
+      "Ugyldig datoformat. Bruk åååå, mm.åååå eller dd.mm.åååå.",
+    temporalDateOrder: "Sluttdato må være etter startdato.",
   },
   button: {
     addDate: "Legg til tidsperiode",
+    openDatePicker: "Åpne datovelger",
     addInformationModel: "Legg til informasjonsmodell",
     addStandard: "Legg til standard",
     addDistribution: "Legg til distribusjon",

--- a/libs/utils/src/lib/language/dataset.form.nb.ts
+++ b/libs/utils/src/lib/language/dataset.form.nb.ts
@@ -194,6 +194,9 @@ Dersom man velger en åpen lisens, vil datasettet bli merket med "Åpne data".`,
     distributionRights: "Rettigheter for bruk",
     mobilityDataStandard: "Mobility-standard",
   },
+  placeholder: {
+    temporalDate: "åååå/mm.åååå/dd.mm.åååå",
+  },
   alert: {
     confirmDelete: "Er du sikker på at du vil slette datasettbeskrivelsen?",
     formError: "Du har feil i skjemaet. Rett opp i disse før du kan lagre.",

--- a/libs/utils/src/lib/language/dataset.form.nb.ts
+++ b/libs/utils/src/lib/language/dataset.form.nb.ts
@@ -53,6 +53,8 @@ Dersom man velger en åpen lisens, vil datasettet bli merket med "Åpne data".`,
     spatial: "Geografiske områder datasettet dekker.",
     temporal:
       "Tidsperiode(r) datasettet dekker. En tidsperiode kan være pågående.",
+    temporalDateFormat:
+      "Oppgi dato som **åååå** (år), **mm.åååå** (måned og år), eller **dd.mm.åååå** (dag, måned og år).",
     lastUpdated: "Dato for siste oppdatering av innholdet i datasettet.",
     landingPage:
       "Lenke til en nettside som gir tilgang til datasettet, dets distribusjoner og/eller tilleggsinformasjon.",


### PR DESCRIPTION
# Summary fixes #1248

- Replace native `type="date"` with `DateFieldWithPicker`, supporting flexible Norwegian formats (`yyyy`, `mm.yyyy`, `dd.mm.yyyy`, `/` separator) plus a native picker fallback
- Add `parseFlexibleDate` / `formatFlexibleDate` / `toCanonicalFlexibleISO` utilities in `@catalog-frontend/utils`
- Fix auto-add: temporal entries now persist only on explicit save, not on every field change
- Update `dateSchema` to validate flexible formats with precision-aware startDate/endDate comparison; new `temporalDateFormat` and `temporalDateOrder` error messages
- Restrict typing in the date field to digits, `.` and `/` via `onBeforeInput`
- Add `HelpMarkdown` tooltip on Fra/Til labels describing accepted formats
- Add unit tests for date utilities and `isAllowedDateChars`, plus e2e tests for validation, picker button, and input restriction

### UX
<img width="579" height="242" alt="Screenshot 2026-04-21 at 08 38 23" src="https://github.com/user-attachments/assets/38665d63-83f6-4d70-bdcd-0e6cccfb7b59" />

<img width="616" height="249" alt="Screenshot 2026-04-21 at 08 39 04" src="https://github.com/user-attachments/assets/f1cc2fbd-a251-43dd-a8a3-fda997b3b961" />

<img width="626" height="345" alt="Screenshot 2026-04-21 at 09 34 09" src="https://github.com/user-attachments/assets/8547a3a8-7a33-4c71-8b86-c6d36d2c2f74" />