### PR TITLE
fix: ignore empty currency combobox selection

### DIFF
--- a/apps/data-service-catalog/components/data-service-form/components/costs-modal/costs-modal.tsx
+++ b/apps/data-service-catalog/components/data-service-form/components/costs-modal/costs-modal.tsx
@@ -150,12 +150,10 @@ export const CostsModal = ({
                           <Combobox
                             value={[values?.currency ?? DEFAULT_CURRENCY]}
                             portal={false}
-                            onValueChange={(selectedValues) =>
-                              setFieldValue(
-                                "currency",
-                                selectedValues.toString(),
-                              )
-                            }
+                            onValueChange={(selectedValues) => {
+                              if (selectedValues.length === 0) return;
+                              setFieldValue("currency", selectedValues[0]);
+                            }}
                             data-size="sm"
                             disabled={!isNumber(values?.value)}
                             hideClearButton


### PR DESCRIPTION
# Summary fixes #1831

- Prevent crash when user clears currency combobox text in the costs modal
- If combobox fires `onValueChange` with an empty array (no selection), the handler now returns early, preserving the previous currency value