### PR TITLE
fix: bump axios resolution to 1.16.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "typescript-eslint": "^8.59.1"
   },
   "resolutions": {
-    "axios": "^1.15.0",
+    "axios": "^1.16.0",
     "lodash": "^4.18.1",
     "lodash-es": "^4.18.1",
     "svgo": "^3.3.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8017,14 +8017,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:^1.15.0":
-  version: 1.15.0
-  resolution: "axios@npm:1.15.0"
+"axios@npm:^1.16.0":
+  version: 1.16.0
+  resolution: "axios@npm:1.16.0"
   dependencies:
-    follow-redirects: "npm:^1.15.11"
+    follow-redirects: "npm:^1.16.0"
     form-data: "npm:^4.0.5"
     proxy-from-env: "npm:^2.1.0"
-  checksum: 10/d39a2c0ebc7ff4739401b282e726cc2673377949d6c46d60eb619458f8d7a2f7eadbcada7097f4dbc7d5c59abb4d3bf6fac33d474412bc3415d3f5aa7ed45530
+  checksum: 10/cf8b521ff732c21550b38c8739aef556ea5e14b268468bb89e4307416ab262b462e582474e810963a3d61c2392ab47ad35c11d05eff027de7c97113bc7411623
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Summary fixes #1890

- Bump `axios` yarn resolution from `^1.15.0` to `^1.16.0`
- Resolves 4 high-severity CVEs (prototype pollution, header injection, NO_PROXY bypass) in the transitive axios dep pulled in by nx@22.7.1