### PR TITLE
fix: reset combobox input on modal close

### DIFF
--- a/apps/dataset-catalog/components/dataset-form/components/relations-section/references-table.tsx
+++ b/apps/dataset-catalog/components/dataset-form/components/relations-section/references-table.tsx
@@ -346,6 +346,7 @@ const FieldModal = ({
                             ? [values.referenceType]
                             : []
                         }
+                        inputValue={values.referenceType ? undefined : ""}
                         placeholder={`${localization.datasetForm.fieldLabel.choseRelation}...`}
                         portal={false}
                         data-size="sm"
@@ -389,6 +390,7 @@ const FieldModal = ({
                             ? [values.source]
                             : []
                         }
+                        inputValue={values.source ? undefined : ""}
                         placeholder={`${localization.search.search}...`}
                         portal={false}
                         data-size="sm"


### PR DESCRIPTION
# Summary fixes #1844

- Add `inputValue` prop to both Comboboxes in the "Legg til relasjon" modal
- When form values are empty, passes `inputValue=""` to force the Combobox to clear its internal display state
- Fixes visual ghost values showing after a relation has been added and the modal is reopened