### PR TITLE
fix: inconsistent popover trigger-button sizes (helptext component)

### DIFF
--- a/libs/ui/src/lib/help-markdown/index.tsx
+++ b/libs/ui/src/lib/help-markdown/index.tsx
@@ -48,6 +48,7 @@ export const HelpMarkdown = forwardRef<HTMLButtonElement, HelpTextProps>(
           className={classNames(styles.helpMarkdown, styles[severity])}
           ref={ref}
           variant="tertiary"
+          data-size="md"
           {...rest}
         />
         <Popover data-size="sm" placement={placement} data-color={severity}>


### PR DESCRIPTION
# Fixes https://github.com/Informasjonsforvaltning/catalog-frontend/issues/1876 

- enforce size=md for popover trigger button