### PR TITLE
fix: Disappearing dialog buttons

### DIFF
--- a/apps/dataset-catalog/components/dataset-form/components/distribution-section/distributions.module.scss
+++ b/apps/dataset-catalog/components/dataset-form/components/distribution-section/distributions.module.scss
@@ -4,7 +4,7 @@
 
 .modalContent {
   margin: var(--ds-size-8) 0;
-  height: calc(100vh - 350px);
+  height: calc(80vh - 175px);
   display: flex;
   flex-direction: column;
   overflow-x: hidden;


### PR DESCRIPTION
fixes https://github.com/Informasjonsforvaltning/catalog-frontend/issues/1915


Fixes issue where dialog buttons would disappear at larger viewport heights. Solution: adjusted dialog inner div size (prev based on 100vh) to be consistent with dialog sizing from Designsystemet component (80vh). 