### PR TITLE
chore: fix uuid security vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,6 +134,7 @@
     "tmp": "^0.2.6",
     "qs": "^6.15.2",
     "ws": "^8.20.1",
+    "uuid": "^11.1.1",
     "webpack-dev-server": "^5.2.4",
     "brace-expansion@^1.1.7": "^1.1.13",
     "brace-expansion@^2.0.1": "^2.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -20383,12 +20383,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uuid@npm:^8.3.2":
-  version: 8.3.2
-  resolution: "uuid@npm:8.3.2"
+"uuid@npm:^11.1.1":
+  version: 11.1.1
+  resolution: "uuid@npm:11.1.1"
   bin:
-    uuid: dist/bin/uuid
-  checksum: 10/9a5f7aa1d6f56dd1e8d5f2478f855f25c645e64e26e347a98e98d95781d5ed20062d6cca2eecb58ba7c84bc3910be95c0451ef4161906abaab44f9cb68ffbdd1
+    uuid: dist/esm/bin/uuid
+  checksum: 10/16411d3dc12a08d6691616c09a75e66a7f900ba1beef6628a76fe0602f82fae2ee537b564d0b7bc95c24f58d059ca9b58c75a1e806118efb50e17822ff00ddd2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Summary

- Add `uuid: ^11.1.1` to resolutions in package.json to fix GHSA-w5hq-g745-h8pq
- Bumps transitive uuid from 8.3.2 to 11.1.1 for next-auth and sockjs dependents