### PR TITLE
fix: bump shell-quote to 1.8.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
     "typescript-eslint": "^8.59.2"
   },
   "resolutions": {
+    "shell-quote": "^1.8.4",
     "axios": "^1.16.0",
     "ip-address": "^10.2.0",
     "lodash": "^4.18.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -18749,10 +18749,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"shell-quote@npm:^1.7.3, shell-quote@npm:^1.8.3":
-  version: 1.8.3
-  resolution: "shell-quote@npm:1.8.3"
-  checksum: 10/5473e354637c2bd698911224129c9a8961697486cff1fb221f234d71c153fc377674029b0223d1d3c953a68d451d79366abfe53d1a0b46ee1f28eb9ade928f4c
+"shell-quote@npm:^1.8.4":
+  version: 1.8.4
+  resolution: "shell-quote@npm:1.8.4"
+  checksum: 10/a3e3796385f2cd5cf0b78207a4439f0c7395c0833fc75b2473084b5d298c109c5c0fa687fcd1c04e4b4484866e5bb8eaae7efae443b80fff71ea7e29baf11f0c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Summary

- Adds shell-quote ^1.8.4 resolution to force the patched transitive version
- Resolves critical Dependabot alert #216 (GHSA shell-quote command injection)