### PR TITLE
feat: use EU licences list for data service licence

### DIFF
--- a/apps/data-service-catalog-e2e/src/page-object-model/dataServiceEditPage.ts
+++ b/apps/data-service-catalog-e2e/src/page-object-model/dataServiceEditPage.ts
@@ -323,7 +323,8 @@ export default class DataServiceEditPage {
   }
 
   async selectLicense(license: string) {
-    await this.licenseGroup.getByRole("combobox").selectOption(license);
+    await this.licenseGroup.getByRole("combobox").click();
+    await this.page.getByRole("option", { name: license, exact: true }).click();
   }
 
   async selectAccessRights(accessRights: string) {

--- a/apps/data-service-catalog/app/catalogs/[catalogId]/data-services/[dataServiceId]/edit/page.tsx
+++ b/apps/data-service-catalog/app/catalogs/[catalogId]/data-services/[dataServiceId]/edit/page.tsx
@@ -6,7 +6,7 @@ import {
 import {
   getCurrencies,
   getDistributionStatuses,
-  getOpenLicenses,
+  getLicences,
   getPlannedAvailabilities,
 } from "@catalog-frontend/data-access";
 import {
@@ -46,7 +46,7 @@ const EditDataServicePage = withWriteProtectedPage(
       availabilitiesResponse,
       currenciesResponse,
     ] = await Promise.all([
-      getOpenLicenses(),
+      getLicences(),
       getDistributionStatuses(),
       getPlannedAvailabilities(),
       getCurrencies(),
@@ -54,7 +54,7 @@ const EditDataServicePage = withWriteProtectedPage(
 
     const referenceData = {
       distributionStatuses: statusResponse.distributionStatuses,
-      openLicenses: licenseResponse.openLicenses,
+      openLicenses: licenseResponse.licences,
       plannedAvailabilities: availabilitiesResponse.plannedAvailabilities,
       currencies: currenciesResponse.currencies,
     };

--- a/apps/data-service-catalog/app/catalogs/[catalogId]/data-services/[dataServiceId]/page.tsx
+++ b/apps/data-service-catalog/app/catalogs/[catalogId]/data-services/[dataServiceId]/page.tsx
@@ -12,7 +12,7 @@ import {
 import {
   getCurrencies,
   getDistributionStatuses,
-  getOpenLicenses,
+  getLicences,
   getPlannedAvailabilities,
 } from "@catalog-frontend/data-access";
 import { redirect, RedirectType } from "next/navigation";
@@ -53,7 +53,7 @@ const EditDataServicePage = withReadProtectedPage(
       availabilitiesResponse,
       currenciesResponse,
     ] = await Promise.all([
-      getOpenLicenses(),
+      getLicences(),
       getDistributionStatuses(),
       getPlannedAvailabilities(),
       getCurrencies(),
@@ -61,7 +61,7 @@ const EditDataServicePage = withReadProtectedPage(
 
     const referenceData = {
       distributionStatuses: statusResponse.distributionStatuses,
-      openLicenses: licenseResponse.openLicenses,
+      openLicenses: licenseResponse.licences,
       plannedAvailabilities: availabilitiesResponse.plannedAvailabilities,
       currencies: currenciesResponse.currencies,
     };

--- a/apps/data-service-catalog/app/catalogs/[catalogId]/data-services/new/page.tsx
+++ b/apps/data-service-catalog/app/catalogs/[catalogId]/data-services/new/page.tsx
@@ -6,7 +6,7 @@ import {
 import {
   getCurrencies,
   getDistributionStatuses,
-  getOpenLicenses,
+  getLicences,
   getPlannedAvailabilities,
 } from "@catalog-frontend/data-access";
 
@@ -28,14 +28,14 @@ const NewDataServicePage = withWriteProtectedPage(
       availabilitiesResponse,
       currenciesResponse,
     ] = await Promise.all([
-      getOpenLicenses(),
+      getLicences(),
       getDistributionStatuses(),
       getPlannedAvailabilities(),
       getCurrencies(),
     ]);
 
     const referenceData = {
-      openLicenses: licenseResponse.openLicenses,
+      openLicenses: licenseResponse.licences,
       distributionStatuses: statusResponse.distributionStatuses,
       plannedAvailabilities: availabilitiesResponse.plannedAvailabilities,
       currencies: currenciesResponse.currencies,

--- a/apps/data-service-catalog/components/data-service-form/components/access-section.tsx
+++ b/apps/data-service-catalog/components/data-service-form/components/access-section.tsx
@@ -1,13 +1,41 @@
-import { DataService, ReferenceDataCode } from "@catalog-frontend/types";
+import {
+  DataService,
+  Option,
+  ReferenceDataCode,
+} from "@catalog-frontend/types";
 import {
   CostsTable,
   FieldsetDivider,
   TitleWithHelpTextAndTag,
 } from "@catalog-frontend/ui";
-import { accessRights, localization } from "@catalog-frontend/utils";
-import { Fieldset } from "@digdir/designsystemet-react";
+import {
+  accessRights,
+  getTranslateText,
+  localization,
+} from "@catalog-frontend/utils";
+import { Combobox, Fieldset } from "@digdir/designsystemet-react";
 import { useFormikContext } from "formik";
 import { ReferenceDataRadioGroup } from "@data-service-catalog/components/data-service-form/components/reference-data-radio-group";
+
+const PRIORITY_LICENCE_CODES = ["CC0", "CC_BY_4_0"];
+
+const containsFilter = (inputValue: string, option: Option): boolean =>
+  option.label.toLowerCase().includes(inputValue.toLowerCase());
+
+const sortLicences = (licences: ReferenceDataCode[]): ReferenceDataCode[] =>
+  [...licences].sort((a, b) => {
+    const a_priority = PRIORITY_LICENCE_CODES.indexOf(a.code ?? "");
+    const b_priority = PRIORITY_LICENCE_CODES.indexOf(b.code ?? "");
+    if (a_priority !== -1 || b_priority !== -1) {
+      return (
+        (a_priority === -1 ? Infinity : a_priority) -
+        (b_priority === -1 ? Infinity : b_priority)
+      );
+    }
+    return getTranslateText(a.label)
+      .toString()
+      .localeCompare(getTranslateText(b.label).toString());
+  });
 
 type Props = {
   openLicenses?: ReferenceDataCode[];
@@ -27,14 +55,34 @@ export const AccessSection = ({ openLicenses, currencies }: Props) => {
             {localization.dataServiceForm.fieldLabel.license}
           </TitleWithHelpTextAndTag>
         </Fieldset.Legend>
-        <ReferenceDataRadioGroup
-          selected={values?.license}
-          codes={openLicenses ?? []}
-          selectCode={(selected) =>
-            setFieldValue("license", selected.toString())
+        <Combobox
+          value={
+            values?.license && values.license !== "none" ? [values.license] : []
           }
-          noneLabel={localization.dataServiceForm.noLicense}
-        />
+          portal={false}
+          onValueChange={(selectedValues) =>
+            setFieldValue("license", selectedValues.toString())
+          }
+          filter={containsFilter}
+          placeholder={`${localization.search.search}...`}
+        >
+          <Combobox.Empty>{localization.search.noHits}</Combobox.Empty>
+          {values?.license &&
+            values.license !== "none" &&
+            !openLicenses?.some((l) => l.uri === values.license) && (
+              <Combobox.Option value={values.license}>
+                {values.license}
+              </Combobox.Option>
+            )}
+          {sortLicences(openLicenses ?? []).map((license, i) => (
+            <Combobox.Option
+              key={`license-${license.uri}-${i}`}
+              value={license.uri}
+            >
+              {getTranslateText(license.label)}
+            </Combobox.Option>
+          ))}
+        </Combobox>
       </Fieldset>
 
       <FieldsetDivider />


### PR DESCRIPTION
  - Replace open-licenses radio group with searchable EU licences combobox in data service access section
  - Fetch /eu/licences (deprecated filtered out) in the 3 data service pages
  - Pin CC0 and CC BY 4.0 to top, rest sorted by displayed label
  