### PR TITLE
feat: add type (service-output-type) to produces

### DIFF
--- a/apps/service-catalog/components/basic-form-info-card-items/index.tsx
+++ b/apps/service-catalog/components/basic-form-info-card-items/index.tsx
@@ -158,9 +158,13 @@ export const BasicServiceFormInfoCardItems = (props: Props) => {
                   <Heading data-size="2xs" level={5}>
                     {localization.serviceForm.fieldLabel.producesType}
                   </Heading>
-                  <Paragraph data-size="sm">
-                    {produce.type?.map(serviceOutputTypeLabel).join(", ")}
-                  </Paragraph>
+                  <ul className={styles.tagList}>
+                    {produce.type?.map((uri) => (
+                      <Tag data-size="sm" data-color="info" key={uri}>
+                        {serviceOutputTypeLabel(uri)}
+                      </Tag>
+                    ))}
+                  </ul>
                 </>
               )}
             </Card>

--- a/apps/service-catalog/components/basic-form-info-card-items/index.tsx
+++ b/apps/service-catalog/components/basic-form-info-card-items/index.tsx
@@ -23,6 +23,7 @@ import {
   localization,
 } from "@catalog-frontend/utils";
 import styles from "./basic-form-info-card-items.module.css";
+import { serviceOutputTypeLabel } from "../service-form/service-output-types";
 
 type Props = {
   language: string;
@@ -148,6 +149,17 @@ export const BasicServiceFormInfoCardItems = (props: Props) => {
                         );
                       })
                       .join(", ")}
+                  </Paragraph>
+                </>
+              )}
+
+              {!isEmpty(produce.type) && (
+                <>
+                  <Heading data-size="2xs" level={5}>
+                    {localization.serviceForm.fieldLabel.producesType}
+                  </Heading>
+                  <Paragraph data-size="sm">
+                    {produce.type?.map(serviceOutputTypeLabel).join(", ")}
                   </Paragraph>
                 </>
               )}

--- a/apps/service-catalog/components/service-form/components/produces-field.tsx
+++ b/apps/service-catalog/components/service-form/components/produces-field.tsx
@@ -37,6 +37,10 @@ import styles from "../service-form.module.css";
 import { type ChangeEvent, useEffect, useRef, useState } from "react";
 import { trim, isEmpty, pickBy, identity } from "lodash";
 import { producesSchema } from "../validation-schema";
+import {
+  SERVICE_OUTPUT_TYPES,
+  serviceOutputTypeLabel,
+} from "../service-output-types";
 
 interface Props {
   errors?:
@@ -172,6 +176,44 @@ const DatasetFieldset = ({ searchEnv }: { searchEnv: string }) => {
   );
 };
 
+const TypeFieldset = () => {
+  const { values, setFieldValue } = useFormikContext<Output>();
+
+  return (
+    <Fieldset data-size="sm">
+      <Fieldset.Legend>
+        <TitleWithHelpTextAndTag
+          helpText={localization.serviceForm.helptext.producesType}
+        >
+          {localization.serviceForm.fieldLabel.producesType}
+        </TitleWithHelpTextAndTag>
+      </Fieldset.Legend>
+      <Combobox
+        data-size="sm"
+        portal={false}
+        multiple
+        hideClearButton
+        value={values.type ?? []}
+        onValueChange={(selectedValues: string[]) =>
+          setFieldValue("type", selectedValues)
+        }
+        placeholder={`${localization.search.search}...`}
+      >
+        <Combobox.Empty>{`${localization.search.noHits}...`}</Combobox.Empty>
+        {SERVICE_OUTPUT_TYPES.map((option) => (
+          <Combobox.Option
+            key={option.uri}
+            value={option.uri}
+            displayValue={option.label}
+          >
+            {option.label}
+          </Combobox.Option>
+        ))}
+      </Combobox>
+    </Fieldset>
+  );
+};
+
 const hasNoFieldValues = (values: Output) => {
   if (!values) return true;
   return (
@@ -299,6 +341,16 @@ export const ProducesField = (props: Props) => {
                   </Paragraph>
                 </div>
               )}
+              {!isEmpty(item.type) && (
+                <div>
+                  <Heading data-size="2xs" level={3}>
+                    {localization.serviceForm.fieldLabel.producesType}
+                  </Heading>
+                  <Paragraph data-size="sm">
+                    {item.type?.map(serviceOutputTypeLabel).join(", ")}
+                  </Paragraph>
+                </div>
+              )}
             </Card>
           ))}
 
@@ -312,6 +364,7 @@ export const ProducesField = (props: Props) => {
               identifier: "",
               language: [],
               isPartOf: [],
+              type: [],
             }}
             type="new"
             onSuccess={() => setSnapshot([...(values.produces ?? [])])}
@@ -410,6 +463,9 @@ const FieldModal = (props: ModalProps) => {
 
                   <FieldsetDivider />
                   <DatasetFieldset searchEnv={searchEnv} />
+
+                  <FieldsetDivider />
+                  <TypeFieldset />
                 </div>
                 <DialogActions>
                   <Button

--- a/apps/service-catalog/components/service-form/service-output-types.ts
+++ b/apps/service-catalog/components/service-form/service-output-types.ts
@@ -1,0 +1,28 @@
+const SERVICE_OUTPUT_TYPE_BASE =
+  "https://data.norge.no/vocabulary/service-output-type";
+
+export const SERVICE_OUTPUT_TYPES: { uri: string; label: string }[] = [
+  { uri: `${SERVICE_OUTPUT_TYPE_BASE}#declaration`, label: "Erklæring" },
+  {
+    uri: `${SERVICE_OUTPUT_TYPE_BASE}#financial-benefit`,
+    label: "Økonomisk fordel",
+  },
+  {
+    uri: `${SERVICE_OUTPUT_TYPE_BASE}#financial-obligation`,
+    label: "Økonomisk forpliktelse",
+  },
+  {
+    uri: `${SERVICE_OUTPUT_TYPE_BASE}#identifier`,
+    label: "Identifikator eller aksesskode",
+  },
+  { uri: `${SERVICE_OUTPUT_TYPE_BASE}#permit`, label: "Tillatelse" },
+  {
+    uri: `${SERVICE_OUTPUT_TYPE_BASE}#physical-object`,
+    label: "Fysisk objekt",
+  },
+  { uri: `${SERVICE_OUTPUT_TYPE_BASE}#recogntion`, label: "Anerkjennelse" },
+  { uri: `${SERVICE_OUTPUT_TYPE_BASE}#rights`, label: "Rettighet" },
+];
+
+export const serviceOutputTypeLabel = (uri: string): string =>
+  SERVICE_OUTPUT_TYPES.find((item) => item.uri === uri)?.label ?? uri;

--- a/apps/service-catalog/components/service-form/service-template.ts
+++ b/apps/service-catalog/components/service-form/service-template.ts
@@ -21,6 +21,7 @@ export const producesTemplate = (produce: Output): Output => {
     },
     language: produce.language ?? [],
     isPartOf: produce.isPartOf ?? [],
+    type: produce.type ?? [],
   };
 };
 
@@ -59,6 +60,7 @@ export const emptyProduces: Output[] = [
     description: { nb: undefined, nn: undefined, en: undefined },
     language: [],
     isPartOf: [],
+    type: [],
   },
 ];
 

--- a/apps/service-catalog/components/service-form/validation-schema.ts
+++ b/apps/service-catalog/components/service-form/validation-schema.ts
@@ -132,6 +132,7 @@ export const producesSchema = Yup.object().shape({
       },
     ),
   isPartOf: Yup.array().of(Yup.string()).notRequired(),
+  type: Yup.array().of(Yup.string()).notRequired(),
 });
 
 const titleSchema = Yup.object()

--- a/libs/types/src/lib/service.ts
+++ b/libs/types/src/lib/service.ts
@@ -28,6 +28,7 @@ export interface Output {
   description?: LocalizedStrings;
   language?: string[];
   isPartOf?: string[];
+  type?: string[];
 }
 
 export interface Evidence {

--- a/libs/utils/src/lib/language/service.form.ts
+++ b/libs/utils/src/lib/language/service.form.ts
@@ -19,6 +19,7 @@ export const serviceFormNb = {
     name: "Navn",
     produces: "Produserer",
     producesDataset: "Er del av",
+    producesType: "Type",
     relatedDocumentation: "Relatert dokumentasjon",
     spatial: "Dekningsområde",
     status: "Status",
@@ -50,6 +51,8 @@ export const serviceFormNb = {
       "Egenskapen brukes til å referere til en eller flere instanser av tjenesteresultat som beskriver resultat av tjenesten.",
     producesDataset:
       "Velg datasett som tjenesteresultatet fysisk eller logisk kan inngå i.",
+    producesType:
+      "Velg hva slags tjenesteresultat det er, fra vokabularet for tjenesteresultattype.",
     relatedDocumentation:
       "Lenker til mer informasjon om dokumentasjonen, for eksempel maler eller veiledning. Hver lenke må være en gyldig URL.",
     spatial: "Geografiske områder som tjenesten dekker.",


### PR DESCRIPTION
# Summary

- Legg til type (dct:type) på mulig tjenesteresulta
- Vis valgt type i produces-kort og detaljvisning
- Legg til type i Output-type, validering og template

