### PR TITLE
fix: bump websocket-driver to 0.7.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
     "typescript-eslint": "^8.59.2"
   },
   "resolutions": {
+    "websocket-driver": "^0.7.5",
     "shell-quote": "^1.8.4",
     "axios": "^1.16.0",
     "ip-address": "^10.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -20766,14 +20766,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"websocket-driver@npm:>=0.5.1, websocket-driver@npm:^0.7.4":
-  version: 0.7.4
-  resolution: "websocket-driver@npm:0.7.4"
+"websocket-driver@npm:^0.7.5":
+  version: 0.7.5
+  resolution: "websocket-driver@npm:0.7.5"
   dependencies:
     http-parser-js: "npm:>=0.5.1"
     safe-buffer: "npm:>=5.1.0"
     websocket-extensions: "npm:>=0.1.1"
-  checksum: 10/17197d265d5812b96c728e70fd6fe7d067471e121669768fe0c7100c939d997ddfc807d371a728556e24fc7238aa9d58e630ea4ff5fd4cfbb40f3d0a240ef32d
+  checksum: 10/0671fef8c79ba1b1b2fa6b7d95cb034d059410e7c4cfd7ef42063a254e12ca2917806c3a5026206b33abf25a5d44a651c547b8f74d9ec94c9fe4df6fa1bc63f7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Summary

- Add websocket-driver ^0.7.5 resolution to fix DoS via long headers (#230 Critical, #231 Moderate)
- Transitive via webpack-dev-server/sockjs; patch bump within 0.7.x
- Verified: concept-catalog builds successfully