### PR TITLE
test: run catalog-portal e2e against production build

### DIFF
--- a/apps/catalog-portal-e2e/playwright.config.ts
+++ b/apps/catalog-portal-e2e/playwright.config.ts
@@ -37,7 +37,7 @@ export default defineConfig({
   /* Run your local dev server before starting the tests */
   webServer: {
     command:
-      "yarn kill-port 4200 && yarn nx serve catalog-portal --configuration=e2e",
+      "yarn kill-port 4200 && yarn nx run catalog-portal:build:production && yarn nx serve catalog-portal --configuration=e2e",
     url: "http://127.0.0.1:4200",
     reuseExistingServer: !process.env.CI,
     cwd: workspaceRoot,

--- a/apps/catalog-portal-e2e/playwright.config.ts
+++ b/apps/catalog-portal-e2e/playwright.config.ts
@@ -41,6 +41,9 @@ export default defineConfig({
     url: "http://127.0.0.1:4200",
     reuseExistingServer: !process.env.CI,
     cwd: workspaceRoot,
+    // e2e runs against a production build (next start), which needs time to
+    // compile before the server is ready — well beyond Playwright's 60s default.
+    timeout: 300 * 1000,
   },
   projects: [
     {

--- a/apps/catalog-portal-e2e/src/page-object-model/catalogPortalPage.ts
+++ b/apps/catalog-portal-e2e/src/page-object-model/catalogPortalPage.ts
@@ -31,10 +31,6 @@ export default class CatalogPortalPage {
 
   public async goto(url: string = this.url) {
     await this.page.goto(url);
-    // Firefox is markedly slower to receive the streamed SSR output for the
-    // catalog navigation cards; wait for the network to settle so the links
-    // are present before assertions run.
-    await this.page.waitForLoadState("networkidle");
   }
 
   public async checkAccessibility() {
@@ -50,9 +46,7 @@ export default class CatalogPortalPage {
     expectedUrl: RegExp,
   ) {
     const locator = (this[locatorFunction] as () => Locator)();
-    // Allow extra time: the nav-card links are streamed in and render later on
-    // Firefox than the 5s default assertion timeout.
-    await expect(locator).toBeVisible({ timeout: 30000 });
+    await expect(locator).toBeVisible();
     await expect(locator).toHaveAttribute("href", expectedUrl);
   }
 }

--- a/apps/catalog-portal-e2e/src/page-object-model/catalogPortalPage.ts
+++ b/apps/catalog-portal-e2e/src/page-object-model/catalogPortalPage.ts
@@ -31,6 +31,10 @@ export default class CatalogPortalPage {
 
   public async goto(url: string = this.url) {
     await this.page.goto(url);
+    // Firefox is markedly slower to receive the streamed SSR output for the
+    // catalog navigation cards; wait for the network to settle so the links
+    // are present before assertions run.
+    await this.page.waitForLoadState("networkidle");
   }
 
   public async checkAccessibility() {
@@ -46,7 +50,9 @@ export default class CatalogPortalPage {
     expectedUrl: RegExp,
   ) {
     const locator = (this[locatorFunction] as () => Locator)();
-    await expect(locator).toBeVisible();
+    // Allow extra time: the nav-card links are streamed in and render later on
+    // Firefox than the 5s default assertion timeout.
+    await expect(locator).toBeVisible({ timeout: 30000 });
     await expect(locator).toHaveAttribute("href", expectedUrl);
   }
 }

--- a/apps/catalog-portal/project.json
+++ b/apps/catalog-portal/project.json
@@ -31,8 +31,8 @@
           "dev": true
         },
         "e2e": {
-          "buildTarget": "catalog-portal:build:development",
-          "dev": true
+          "buildTarget": "catalog-portal:build:production",
+          "dev": false
         },
         "production": {
           "buildTarget": "catalog-portal:build:production",


### PR DESCRIPTION
# Summary

- catalog-portal e2e `serve` (`--configuration=e2e`) now runs a **production build** (`dev: false`, `build:production`) instead of `next dev` (turbopack)
- Added `webServer.timeout: 300s` so the production build has time to start

## Root cause
The 5 firefox-only `catalog-portal` nav-card failures are a **turbopack-dev SSR-streaming regression** in Next.js (green on 16.2.6, broken 16.2.8→16.2.12; `controller[kState].transformAlgorithm is not a function` in the dev server, firefox only). The production build (`@nx/next:build`, which is what deploys) is unaffected. Running the e2e against the production server both fixes the failure and makes the test representative of what ships.

Verified via bisect: 16.2.6 e2e green, 16.2.8/16.2.10/16.2.12 red — all in turbopack dev mode.